### PR TITLE
feat: extend GetEnumTypes to include enums from EfCoreDbContext for i…

### DIFF
--- a/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/PostgresEnumExtensions.cs
+++ b/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/PostgresEnumExtensions.cs
@@ -12,7 +12,9 @@ namespace Dosaic.Plugins.Persistence.EfCore.NpgSql
         private static readonly NpgsqlSnakeCaseNameTranslator _translator = new();
 
         private static HashSet<Type> GetEnumTypes(Type modelType) =>
-            modelType.GetAssemblyTypes(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>()).ToHashSet();
+            modelType.GetAssemblyTypes(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>())
+                .Union(typeof(EfCoreDbContext).GetAssemblyTypes(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>()))
+                .ToHashSet();
 
         public static void MapDbEnums<TDbContext>(this ModelBuilder builder)
         {


### PR DESCRIPTION
This pull request updates the `PostgresEnumExtensions` class to enhance its ability to retrieve enum types for database mapping by including enums from the `EfCoreDbContext` assembly in addition to the provided model type's assembly.

Enhancements to enum type retrieval:

* [`Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/PostgresEnumExtensions.cs`](diffhunk://#diff-3c6b9cf46419c75d820bac4d5f0bd0b6e90e299121b42bca5e1216111cbd1495L15-R17): Modified the `GetEnumTypes` method to include enum types from the `EfCoreDbContext` assembly, ensuring that all relevant enums with the `DbEnumAttribute` are considered during database mapping.