### PR TITLE
[Feature] Plugin Hangfire: Allow setting max argument size to render

### DIFF
--- a/Plugins/Jobs/Hangfire/src/Dosaic.Plugins.Jobs.Hangfire/HangFirePlugin.cs
+++ b/Plugins/Jobs/Hangfire/src/Dosaic.Plugins.Jobs.Hangfire/HangFirePlugin.cs
@@ -40,6 +40,7 @@ namespace Dosaic.Plugins.Jobs.Hangfire
             serviceCollection.AddHangfire(conf =>
                 {
                     conf.UseSerializerSettings(new JsonSerializerSettings());
+                    conf.UseMaxArgumentSizeToRender(_hangfireConfig.MaxJobArgumentsSizeToRenderInBytes);
                     if (_hangfireConfig.InMemory)
                         conf.UseMemoryStorage();
                     else

--- a/Plugins/Jobs/Hangfire/src/Dosaic.Plugins.Jobs.Hangfire/HangfireConfiguration.cs
+++ b/Plugins/Jobs/Hangfire/src/Dosaic.Plugins.Jobs.Hangfire/HangfireConfiguration.cs
@@ -19,5 +19,6 @@ namespace Dosaic.Plugins.Jobs.Hangfire
         public string[] Queues { get; set; } = [EnqueuedState.DefaultQueue];
         public int InvisibilityTimeoutInMinutes { get; set; } = 30;
         public string ConnectionString => $"Host={Host};Port={Port};Database={Database};Username={User};Password={Password};";
+        public int MaxJobArgumentsSizeToRenderInBytes { get; set; } = 4096;
     }
 }


### PR DESCRIPTION
This pull request introduces a new configuration option for Hangfire to limit the size of job arguments rendered in the dashboard. The changes ensure better control over resource usage and improve the plugin's configurability.

### Enhancements to Hangfire configuration:

* [`Dosaic.Plugins.Jobs.Hangfire/HangfireConfiguration.cs`](diffhunk://#diff-53322a2e51ef0c225549273eacc634da734ffd00444d61aa8efeebf1ae790169R22): Added a new property, `MaxJobArgumentsSizeToRenderInBytes`, with a default value of `4096`. This property allows users to define the maximum size of job arguments to render.
* [`Dosaic.Plugins.Jobs.Hangfire/HangFirePlugin.cs`](diffhunk://#diff-0fe8a1414725b85d2e405c65979bc995a91c264a4355aa915138ecbfbec95153R43): Updated the `ConfigureServices` method to utilize the new `MaxJobArgumentsSizeToRenderInBytes` property by calling `conf.UseMaxArgumentSizeToRender`.