### PR TITLE
fix: update BlobStorageBucketMigrationService to use bucket names dir…

### DIFF
--- a/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/Blob/BlobStorageBucketMigrationService.cs
+++ b/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/Blob/BlobStorageBucketMigrationService.cs
@@ -23,7 +23,7 @@ internal class BlobStorageBucketMigrationService<T>(IMinioClient minioClient, IL
                     .ToList();
 
                 var existingBuckets =
-                    (await minioClient.ListBucketsAsync(stoppingToken)).Buckets.Select(x => storage.ResolveBucketName(x.Name)).ToList();
+                    (await minioClient.ListBucketsAsync(stoppingToken)).Buckets.Select(x => x.Name).ToList();
 
                 var missingBuckets = requiredBuckets.Except(existingBuckets).ToList();
                 logger.LogInformation("S3 buckets<{bucketType} {@Buckets}", bucketTypeName,
@@ -40,7 +40,7 @@ internal class BlobStorageBucketMigrationService<T>(IMinioClient minioClient, IL
                     logger.LogInformation("S3 buckets<{bucketType}>: create missing bucket {missingBucket}",
                         bucketTypeName, missingBucket);
                     await minioClient.MakeBucketAsync(
-                        new MakeBucketArgs().WithBucket(storage.ResolveBucketName(missingBucket)), stoppingToken);
+                        new MakeBucketArgs().WithBucket(missingBucket), stoppingToken);
                 }
 
                 return;

--- a/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/Arg.cs
+++ b/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/Arg.cs
@@ -1,7 +1,6 @@
 using FluentAssertions.Execution;
 using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
-using NUnit.Framework;
 
 namespace Dosaic.Testing.NUnit.Extensions;
 
@@ -32,9 +31,6 @@ public static class ArgExt
             {
                 return true;
             }
-
-            failures.ForEach(x => TestContext.Error.WriteLine("error " + x));
-            failures.ForEach(x => Console.WriteLine(x));
 
             return false;
         }


### PR DESCRIPTION
This pull request includes changes to improve the S3 bucket migration logic and enhance the associated unit tests. It also introduces minor cleanup in the `Arg` extension utility. The most important changes involve simplifying bucket naming logic, refining test assertions, and improving error handling.

### Improvements to S3 bucket migration logic:

* [`BlobStorageBucketMigrationService.cs`](diffhunk://#diff-84339cdf6066caf5a226cca1b9a66cdc271d0c311bcf5313da00e21049b7b149L26-R26): Simplified bucket naming logic by directly using `Bucket.Name` without resolving it through `storage.ResolveBucketName`. This change applies both when listing existing buckets and creating new ones. [[1]](diffhunk://#diff-84339cdf6066caf5a226cca1b9a66cdc271d0c311bcf5313da00e21049b7b149L26-R26) [[2]](diffhunk://#diff-84339cdf6066caf5a226cca1b9a66cdc271d0c311bcf5313da00e21049b7b149L43-R43)

### Enhancements to unit tests:

* [`BlobStorageBucketMigrationServiceTests.cs`](diffhunk://#diff-60c0727685ccc18847661773df7d4805fe3c5be3cd14764772c0625b7710543fL24-R32): Updated test data to include multiple buckets and refined assertions to verify specific bucket names during the migration process using the `ArgExt.Is` utility. Added checks for bucket creation calls to ensure correctness. [[1]](diffhunk://#diff-60c0727685ccc18847661773df7d4805fe3c5be3cd14764772c0625b7710543fL24-R32) [[2]](diffhunk://#diff-60c0727685ccc18847661773df7d4805fe3c5be3cd14764772c0625b7710543fL36-R49)
* [`BlobStorageBucketMigrationServiceTests.cs`](diffhunk://#diff-60c0727685ccc18847661773df7d4805fe3c5be3cd14764772c0625b7710543fL67-R81): Improved error message formatting in retry logic assertions for better readability.

### Cleanup in `Arg` extension utility:

* [`Arg.cs`](diffhunk://#diff-f4a46a1e5117e21ae006c870ecf2bf3a9cc01bb9062ac07e3070c5fbbc14322aL36-L38): Removed redundant error logging to streamline the `IsSatisfiedBy` method, ensuring cleaner output during test execution.