### PR TITLE
hangfire: unique per queue attribute compared the wrong job args

### DIFF
--- a/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileBucketExtensions.cs
+++ b/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileBucketExtensions.cs
@@ -12,6 +12,16 @@ public static class FileBucketExtensions
         return typeof(T).GetMember(bucket.ToString())[0].GetCustomAttribute<FileBucketAttribute>()!;
     }
 
+    public static T GetEnumValueFromAttributeName<T>(this string bucket) where T : Enum
+    {
+        var enumValue = typeof(T).GetMembers()
+            .FirstOrDefault(x => x.GetCustomAttribute<FileBucketAttribute>()?.Name == bucket);
+        Enum.TryParse(typeof(T), enumValue?.Name, true, out var result);
+        return result != null
+            ? (T)result
+            : throw new ArgumentException($"No enum value found for bucket name '{bucket}' in {typeof(T).Name}.");
+    }
+
     public static string GetName<T>(this T bucket) where T : Enum => GetBucketAttribute(bucket).Name;
     public static FileType GetFileType<T>(this T bucket) where T : Enum => GetBucketAttribute(bucket).FileType;
 

--- a/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileBucketExtensions.cs
+++ b/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileBucketExtensions.cs
@@ -12,7 +12,7 @@ public static class FileBucketExtensions
         return typeof(T).GetMember(bucket.ToString())[0].GetCustomAttribute<FileBucketAttribute>()!;
     }
 
-    public static T GetEnumValueFromAttributeName<T>(this string bucket) where T : Enum
+    public static T GetEnumValueFromAttributeName<T>(string bucket) where T : Enum
     {
         var enumValue = typeof(T).GetMembers()
             .FirstOrDefault(x => x.GetCustomAttribute<FileBucketAttribute>()?.Name == bucket);

--- a/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileId.cs
+++ b/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileId.cs
@@ -28,7 +28,7 @@ public readonly struct FileId<TBucket>(TBucket bucket, string key) : IFileIdKey
     public static FileId<TBucket> FromSqid(string fileId)
     {
         var (bucketName, key) = FileIdExtensions.SplitFromSqid(fileId);
-        return new FileId<TBucket>(bucketName.GetEnumValueFromAttributeName<TBucket>(), key);
+        return new FileId<TBucket>(FileBucketExtensions.GetEnumValueFromAttributeName<TBucket>(bucketName), key);
     }
 
     public FileId ToFileId() => new(Bucket.GetName(), Key);

--- a/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileId.cs
+++ b/Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileId.cs
@@ -28,8 +28,7 @@ public readonly struct FileId<TBucket>(TBucket bucket, string key) : IFileIdKey
     public static FileId<TBucket> FromSqid(string fileId)
     {
         var (bucketName, key) = FileIdExtensions.SplitFromSqid(fileId);
-        var bucket = Enum.Parse<TBucket>(bucketName, true);
-        return new FileId<TBucket>(bucket, key);
+        return new FileId<TBucket>(bucketName.GetEnumValueFromAttributeName<TBucket>(), key);
     }
 
     public FileId ToFileId() => new(Bucket.GetName(), Key);

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/BlobStorageBucketMigrationServiceTests.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/BlobStorageBucketMigrationServiceTests.cs
@@ -42,10 +42,10 @@ public class BlobStorageBucketMigrationServiceTests
         await svc.StopAsync(CancellationToken.None);
         await mc.Received(2).ListBucketsAsync(Arg.Any<CancellationToken>());
         await mc.Received(1)
-            .MakeBucketAsync(ArgExt.Is<MakeBucketArgs>(m => m.GetInaccessibleValue<string>("BucketName").Should().Be("dev-logos")),
+            .MakeBucketAsync(ArgExt.Is<MakeBucketArgs>(m => m.GetInaccessibleValue<string>("BucketName").Should().Be("dev-test-logos")),
                 Arg.Any<CancellationToken>());
         await mc.Received(1)
-            .MakeBucketAsync(ArgExt.Is<MakeBucketArgs>(m => m.GetInaccessibleValue<string>("BucketName").Should().Be("dev-docs")),
+            .MakeBucketAsync(ArgExt.Is<MakeBucketArgs>(m => m.GetInaccessibleValue<string>("BucketName").Should().Be("dev-test.docs")),
                 Arg.Any<CancellationToken>());
 
         fakeLogger.Entries[0].Message.Should().Be("Could not migrate s3 buckets<SampleBucket> -> retrying");
@@ -53,8 +53,8 @@ public class BlobStorageBucketMigrationServiceTests
         // fakelogger does not resolve nested lists and objects but serilog does
         fakeLogger.Entries[1].Message.Should().Be(
             "S3 buckets<SampleBucket { MissingBuckets = System.Collections.Generic.List`1[System.String], RequiredBuckets = System.Collections.Generic.List`1[System.String], ExistingBuckets = System.Collections.Generic.List`1[System.String] }");
-        fakeLogger.Entries[2].Message.Should().Be("S3 buckets<SampleBucket>: create missing bucket dev-logos");
-        fakeLogger.Entries[3].Message.Should().Be("S3 buckets<SampleBucket>: create missing bucket dev-docs");
+        fakeLogger.Entries[2].Message.Should().Be("S3 buckets<SampleBucket>: create missing bucket dev-test-logos");
+        fakeLogger.Entries[3].Message.Should().Be("S3 buckets<SampleBucket>: create missing bucket dev-test.docs");
     }
 
     [Test]

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileBucketExtensionsTests.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileBucketExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Dosaic.Plugins.Persistence.S3.Tests
         [Test]
         public void GetNameReturnsCorrectNameFromAttribute()
         {
-            SampleBucket.Logos.GetName().Should().Be("logos");
+            SampleBucket.Logos.GetName().Should().Be("test-logos");
         }
 
         [Test]

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileIdTests.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileIdTests.cs
@@ -28,7 +28,7 @@ namespace Dosaic.Plugins.Persistence.S3.Tests
         [Test]
         public void TryParseReturnsTrueForValidFileIdGeneric()
         {
-            FileId<SampleBucket>.TryParse("eGcaFP58ojhMILeDDblrzRd", out var fileId).Should().BeTrue();
+            FileId<SampleBucket>.TryParse("PC56XSF10dCDJaiuc4VWu6Se9bQNoyHpj68a2", out var fileId).Should().BeTrue();
             var stringId = fileId.Id;
             var newSecretId = FileId<SampleBucket>.FromSqid(stringId);
             newSecretId.Should().Be(fileId);

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileStorageTests.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/FileStorageTests.cs
@@ -199,7 +199,7 @@ namespace Dosaic.Plugins.Persistence.S3.Tests
                     imgStream)).Should().ThrowAsync<DosaicException>()).Subject.First();
             ex.HttpStatus.Should()
                 .Be(StatusCodes.Status500InternalServerError);
-            ex.Message.Should().Be("Could not save file dev-logos:test to s3");
+            ex.Message.Should().Be("Could not save file dev-test-logos:test to s3");
         }
 
         [Test]

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/SampleBucket.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/SampleBucket.cs
@@ -4,9 +4,9 @@ namespace Dosaic.Plugins.Persistence.S3.Tests;
 
 public enum SampleBucket
 {
-    [FileBucket("logos", FileType.Images)]
+    [FileBucket("test-logos", FileType.Images)]
     Logos = 0,
 
-    [FileBucket("docs", FileType.Documents)]
+    [FileBucket("test.docs", FileType.Documents)]
     Documents
 }


### PR DESCRIPTION
This pull request includes changes to improve job uniqueness handling in the `Hangfire` plugin and updates to bucket naming conventions in the `S3` persistence plugin. The most significant changes involve refactoring the logic for job argument serialization, adding support for retrieving enum values from attribute names, and updating test cases to reflect the new bucket names.

### Hangfire Plugin Changes:
* Refactored job argument serialization logic by introducing a new helper method `GetJobArgsAsString` to simplify and centralize the serialization process. (`UniquePerQueueAttribute.cs`, [[1]](diffhunk://#diff-978cfb98fa5729d278851d86821087a53aefc962641cd82d5298d042505887e2L49-R52) [[2]](diffhunk://#diff-978cfb98fa5729d278851d86821087a53aefc962641cd82d5298d042505887e2R62-R68)
* Enhanced test coverage by adding a new test case `ParameterizedJobRemovesTheDuplicateFromEnqueuedOnesTwo` and modifying existing test cases to use parameterized job payloads. (`UniquePerQueueAttributeTests.cs`, [[1]](diffhunk://#diff-ed0b6bf8276b3b01b49c36e388b2b6e322fd45e697d5bce3ade1e825977f1680R153-R173) [[2]](diffhunk://#diff-ed0b6bf8276b3b01b49c36e388b2b6e322fd45e697d5bce3ade1e825977f1680L213-R233)

### S3 Persistence Plugin Changes:
* Added a new method `GetEnumValueFromAttributeName` to retrieve enum values based on their associated `FileBucketAttribute` names, improving flexibility in bucket handling. (`FileBucketExtensions.cs`, [Plugins/Persistence/S3/src/Dosaic.Plugins.Persistence.S3/File/FileBucketExtensions.csR15-R24](diffhunk://#diff-40473186161055687978ec19d301a758c7d016c96b77dfa726fe0c21ad66e7f8R15-R24))
* Updated bucket names in the `SampleBucket` enum to reflect new naming conventions (e.g., "logos" → "test-logos"). (`SampleBucket.cs`, [Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/SampleBucket.csL7-R10](diffhunk://#diff-72dd2c1c9a64dd33161b548b32a15306cd84604a3aeee3302e0acb50d34c606fL7-R10))
* Modified test cases to use the updated bucket names and ensure compatibility with the new naming conventions. (`BlobStorageBucketMigrationServiceTests.cs`, [[1]](diffhunk://#diff-60c0727685ccc18847661773df7d4805fe3c5be3cd14764772c0625b7710543fL45-R57); `FileBucketExtensionsTests.cs`, [[2]](diffhunk://#diff-d18c564a010b185ecc6482148d5b9eed31e198fcb36147bd617564815ad4bb7cL15-R15); `FileIdTests.cs`, [[3]](diffhunk://#diff-ab437f14a58360fe45d1280f95cdc43463da78a7fa228e528ffb294ce139899dL31-R31); `FileStorageTests.cs`, [[4]](diffhunk://#diff-3bd449c758445ac341db4647a5920cc03feb9fee01d1af0e0e9f046f5cbd9a60L202-R202)

These changes enhance code maintainability, improve test coverage, and align bucket naming conventions with updated requirements.