### PR TITLE
[FIX] Plugin Mapster: Only select adapt when collection is not null

### DIFF
--- a/Plugins/Mapping/Mapster/src/Dosaic.Plugins.Mapping.Mapster/MapsterInitializer.cs
+++ b/Plugins/Mapping/Mapster/src/Dosaic.Plugins.Mapping.Mapster/MapsterInitializer.cs
@@ -78,7 +78,14 @@ namespace Dosaic.Plugins.Mapping.Mapster
                         .First(m => m.Name == "Select" && m.GetParameters().Length == 2)
                         .MakeGenericMethod(elementType, targetElementType);
 
-                    body = Expression.Call(selectMethod, Expression.PropertyOrField(body, paths[i]), collectionLambda);
+                    var propAccess = Expression.PropertyOrField(body, paths[i]);
+                    var selectCall = Expression.Call(selectMethod, propAccess, collectionLambda);
+                    var nullCheck = Expression.Equal(propAccess, Expression.Constant(null, propAccess.Type));
+                    var conditional = Expression.Condition(nullCheck,
+                        Expression.Constant(null, typeof(IEnumerable<>).MakeGenericType(targetElementType)),
+                        selectCall);
+
+                    body = conditional;
                     break;
                 }
                 body = Expression.PropertyOrField(body, paths[i]);

--- a/Plugins/Mapping/Mapster/test/Dosaic.Plugins.Mapping.Mapster.Tests/Dosaic.Plugins.Mapping.Mapster.Tests.csproj
+++ b/Plugins/Mapping/Mapster/test/Dosaic.Plugins.Mapping.Mapster.Tests/Dosaic.Plugins.Mapping.Mapster.Tests.csproj
@@ -9,4 +9,8 @@
       <ProjectReference Include="..\..\src\Dosaic.Plugins.Mapping.Mapster\Dosaic.Plugins.Mapping.Mapster.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    </ItemGroup>
+
 </Project>

--- a/Plugins/Mapping/Mapster/test/Dosaic.Plugins.Mapping.Mapster.Tests/MapsterPluginTests.cs
+++ b/Plugins/Mapping/Mapster/test/Dosaic.Plugins.Mapping.Mapster.Tests/MapsterPluginTests.cs
@@ -11,7 +11,9 @@ public class SourceMapTest
 {
     public int Id { get; set; }
     public NestedClass Nested { get; set; } = null!;
+    public NestedClass2 NestedNull { get; set; } = null!;
     public required List<NestedClass> Classes { get; set; }
+    public List<NestedClass2> NullList { get; set; }
 }
 
 public class NestedClass
@@ -36,6 +38,12 @@ public class TargetClass
     public IEnumerable<NestedClass2> Classes { get; set; } = null!;
 
     public NestedClass2 Nested { get; set; } = null!;
+
+    [MapFrom<SourceMapTest>(nameof(SourceMapTest.NestedNull))]
+    public NestedClass2 NestedNull { get; set; } = null!;
+
+    [MapFrom<SourceMapTest>(nameof(SourceMapTest.NullList))]
+    public IEnumerable<NestedClass2> NullList { get; set; } = null!;
 }
 
 public class MapsterPluginTests
@@ -77,7 +85,9 @@ public class MapsterPluginTests
                 new() { Name = "A", Id = 123 },
                 new() { Name = "B", Id = 1234 }
             ],
-            Nested = new NestedClass { Name = "C", Id = 12345 }
+            Nested = new NestedClass { Name = "C", Id = 12345 },
+            NullList = null,
+            NestedNull = null
         };
         var target = src.Adapt<TargetClass>();
         target.Id.Should().Be(1);
@@ -89,5 +99,6 @@ public class MapsterPluginTests
         target.Classes.Should().Contain(x => x.Name == "B" && x.Id == 1234);
         target.Nested.Id.Should().Be(12345);
         target.Nested.Name.Should().Be("C");
+        target.NullList.Should().BeNull();
     }
 }


### PR DESCRIPTION
This pull request enhances the `MapsterInitializer` and its associated test suite to handle null values gracefully during mapping operations. The most significant changes include modifying the expression tree to add null checks, expanding test coverage with new properties, and validating null handling in mapping scenarios.

### Enhancements to null handling in mapping:

* [`MapsterInitializer.cs`](diffhunk://#diff-04f36268705f06da4392f98264bbe3c6f88ba81432e40d147d1df34f818ed9eeL81-R88): Updated the `BuildExpressionTree` method to include a null check and conditional logic for collections, ensuring that null values are handled properly during mapping operations.

### Test suite updates:

* [`MapsterPluginTests.cs`](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeR14-R16): Added new properties (`NestedNull` and `NullList`) to `SourceMapTest` and `TargetClass` for testing null handling. These properties are mapped using the `[MapFrom]` attribute. [[1]](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeR14-R16) [[2]](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeR41-R46)
* [`MapsterPluginTests.cs`](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeL80-R90): Enhanced the `MapsCorrectly` test to include scenarios where `NullList` and `NestedNull` are null, and added assertions to validate that null values are mapped correctly. [[1]](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeL80-R90) [[2]](diffhunk://#diff-2c735e578b1efa35e4d4415911676d88fb0122f692488a2d729d9f7acbb31eaeR102)