### PR TITLE
[IMPROVEMENT] Add type extension method to get clean name

### DIFF
--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
@@ -45,5 +45,13 @@ namespace Dosaic.Hosting.Abstractions.Extensions
                 });
         }
         public static IList<Type> GetAssemblyTypes(this Type t, Predicate<Type> typePredicate = null) => t.Assembly.GetTypes(typePredicate);
+        public static string GetNormalizedName(this Type type)
+        {
+            if (!type.IsGenericType) return type.Name;
+            var nonGenericTypeName = type.Name.Split('`')[0];
+            if (type.IsGenericTypeDefinition) return $"{nonGenericTypeName}<{new string(',', type.GetGenericArguments().Length - 1)}>";
+            var genericArguments = type.GetGenericArguments();
+            return $"{nonGenericTypeName}<{string.Join(", ", genericArguments.Select(GetNormalizedName))}>";
+        }
     }
 }

--- a/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/TypeExtensionTests.cs
+++ b/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/TypeExtensionTests.cs
@@ -28,6 +28,17 @@ namespace Dosaic.Hosting.Abstractions.Tests.Extensions
             type.Implements(typeof(Generic<>)).Should().BeTrue();
             type.Implements(typeof(Generic<int>)).Should().BeTrue();
         }
+
+        [Test]
+        public void CanGetNormalizedNamesFromTypes()
+        {
+            typeof(int).GetNormalizedName().Should().Be("Int32");
+            typeof(decimal).GetNormalizedName().Should().Be("Decimal");
+            typeof(List<>).GetNormalizedName().Should().Be("List<>");
+            typeof(List<int>).GetNormalizedName().Should().Be("List<Int32>");
+            typeof(Dictionary<int, string>).GetNormalizedName().Should().Be("Dictionary<Int32, String>");
+            typeof(IDictionary<int, IList<decimal>>).GetNormalizedName().Should().Be("IDictionary<Int32, IList<Decimal>>");
+        }
     }
 
     [AttributeUsage(AttributeTargets.Class)]


### PR DESCRIPTION
This pull request introduces a new utility method, `GetNormalizedName`, to the `TypeExtensions` class, which provides a standardized way to retrieve type names, including handling generic types. Corresponding unit tests have also been added to ensure the correctness of the new method.

### New utility method:
* [`Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs`](diffhunk://#diff-729a0fefaf385000ff8d9252f73b1bab6ef95e98345ecc57d7b11bb5199282b8R48-R55): Added the `GetNormalizedName` method to normalize type names, including support for generic types and their arguments.

### Unit tests:
* [`Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/TypeExtensionTests.cs`](diffhunk://#diff-6c5d8545116b03e69a96c098301f2d0a2c0ebb03742f9a046cb39073201452f5R31-R41): Added the `CanGetNormalizedNamesFromTypes` test to validate the behavior of the `GetNormalizedName` method for various types, including primitives, generic type definitions, and nested generics.