### PR TITLE
Adjust Patch-Method

### DIFF
--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/EnumExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/EnumExtensions.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace Dosaic.Hosting.Abstractions.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static bool IsFlagSet<T>(this T value, T flag) where T : Enum
+        {
+            var intValue = Convert.ToInt32(value, CultureInfo.InvariantCulture);
+            var flagValue = Convert.ToInt32(flag, CultureInfo.InvariantCulture);
+            return (intValue & flagValue) == flagValue;
+        }
+    }
+}

--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/ObjectExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/ObjectExtensions.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace Dosaic.Hosting.Abstractions.Extensions
+{
+    [Flags]
+    public enum PatchMode
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        Full = 1,
+        IgnoreLists = 2,
+        IgnoreObjects = 4,
+        OverwriteLists = 8
+    }
+
+    public static class ObjectExtensions
+    {
+
+        /// <summary>
+        /// Patches non-null properties from <paramref name="patch"/> into <paramref name="value"/>.
+        /// If a property is a list, new items will be added to the existing list or overriden (see PatchMode>.
+        /// </summary>
+        /// <param name="value">Value to be patched</param>
+        /// <param name="patch">The patch to apply</param>
+        /// <param name="mode">The mode (default: full)</param>
+        /// <param name="filter">Optional filter for type and properties</param>
+        /// <typeparam name="T"></typeparam>
+        public static void DeepPatch<T>(this T value, T patch, PatchMode mode = PatchMode.Full, Func<Type, PropertyInfo, bool> filter = null) where T : class
+        {
+            DeepPatchInternal(value, patch, mode,
+                (t, p) => p.CanRead && p.CanWrite && (filter == null || filter(t, p)));
+        }
+
+        private static object DeepPatchInternal(object value, object patch, PatchMode mode, Func<Type, PropertyInfo, bool> filter)
+        {
+            if (value is null || patch is null) return value ?? patch;
+            var ignoreLists = mode.IsFlagSet(PatchMode.IgnoreLists);
+            var ignoreObjects = mode.IsFlagSet(PatchMode.IgnoreObjects);
+            var overwriteLists = mode.IsFlagSet(PatchMode.OverwriteLists);
+            var type = value.GetType();
+            if (type.IsEnumerable())
+            {
+                return ignoreLists ? value : GetListValue(type.GenericTypeArguments[0], value, patch);
+            }
+            var props = type.GetProperties().Where(x => filter(type, x));
+            foreach (var prop in props)
+            {
+                var newValue = prop.GetValue(patch);
+                var oldValue = prop.GetValue(value);
+                if (newValue is null || newValue.Equals(oldValue))
+                    continue;
+                if (prop.PropertyType.IsEnumerable())
+                {
+                    if (ignoreLists) continue;
+                    if (!overwriteLists)
+                    {
+                        newValue = GetListValue(prop.PropertyType.GenericTypeArguments[0], oldValue, newValue);
+                    }
+                }
+                else if (prop.PropertyType.IsClass && prop.PropertyType != typeof(string))
+                {
+                    if (ignoreObjects) continue;
+                    newValue = DeepPatchInternal(oldValue, newValue, mode, filter);
+                }
+                prop.SetValue(value, newValue);
+            }
+            return value;
+        }
+
+        private static object GetListValue(Type innerType, object oldValue, object newValue)
+        {
+            oldValue ??=
+                Activator.CreateInstance(
+                    typeof(Collection<>).MakeGenericType(innerType));
+
+            if (oldValue is not IList list || newValue is not IList newList) return null;
+
+            foreach (var newItem in newList)
+                if (!list.Contains(newItem))
+                    list.Add(newItem);
+            return list;
+        }
+    }
+}

--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Reflection;
 
 namespace Dosaic.Hosting.Abstractions.Extensions
@@ -52,6 +53,11 @@ namespace Dosaic.Hosting.Abstractions.Extensions
             if (type.IsGenericTypeDefinition) return $"{nonGenericTypeName}<{new string(',', type.GetGenericArguments().Length - 1)}>";
             var genericArguments = type.GetGenericArguments();
             return $"{nonGenericTypeName}<{string.Join(", ", genericArguments.Select(GetNormalizedName))}>";
+        }
+
+        public static bool IsEnumerable(this Type type)
+        {
+            return type.IsGenericType && type.GetInterfaces().Any(i => i == typeof(IEnumerable));
         }
     }
 }

--- a/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
@@ -1,0 +1,132 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Dosaic.Hosting.Abstractions.Extensions;
+using NUnit.Framework;
+
+namespace Dosaic.Hosting.Abstractions.Tests.Extensions
+{
+    public class ObjectExtensionsTests
+    {
+        private BigClass _source;
+
+        [SetUp]
+        public void Up()
+        {
+            _source = new BigClass
+            {
+                Id = "123",
+                Name = "test",
+                Age = 19,
+                Nested = new BigClassNested { Name = "nested", Id = "nested-id" },
+                NestedList =
+                [
+                    new BigClassNested { Name = "nested0", Id = "nested-id0" },
+                    new BigClassNested { Name = "nested1", Id = "nested-id1" }
+                ],
+                Tags = ["a", "b", "c"]
+            };
+        }
+
+        [Test]
+        public void PatchWorksForNormalProps()
+        {
+            var patch = new BigClass { Id = "124", Name = "patched", Age = 20 };
+            _source.DeepPatch(patch);
+            _source.Id.Should().Be("124");
+            _source.Name.Should().Be("patched");
+            _source.Age.Should().Be(20);
+            _source.NextAge.Should().Be(21);
+            _source.Nested.Id.Should().Be("nested-id");
+            _source.Nested.Name.Should().Be("nested");
+            _source.Tags.Should().HaveCount(3);
+            _source.NestedList.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void PatchWorksWithLists()
+        {
+            var src = new List<int> { 1, 2, 5 };
+            var patch = new List<int> { 1, 2, 3 };
+            src.DeepPatch(patch);
+            src.Should().HaveCount(4);
+            src.Should().Contain([1, 2, 3, 5]);
+
+            src = [1, 2, 5];
+            src.DeepPatch(patch, PatchMode.IgnoreLists);
+            src.Should().Contain([1, 2, 5]);
+
+            var patchCls = new BigClass
+            {
+                Tags = ["abc"],
+                NestedList =
+                [
+                    new BigClassNested { Name = "UPDATE", Id = "UPDATE" }
+                ]
+            };
+            _source.DeepPatch(patchCls);
+            _source.Tags.Should().HaveCount(4);
+            _source.Tags.Should().Contain(["a", "b", "c", "abc"]);
+            _source.NestedList.Should().HaveCount(3);
+            _source.NestedList[0].Id.Should().Be("nested-id0");
+            _source.NestedList[0].Name.Should().Be("nested0");
+            _source.NestedList[1].Id.Should().Be("nested-id1");
+            _source.NestedList[1].Name.Should().Be("nested1");
+            _source.NestedList[2].Id.Should().Be("UPDATE");
+            _source.NestedList[2].Name.Should().Be("UPDATE");
+
+            _source.DeepPatch(patchCls, PatchMode.OverwriteLists);
+            _source.Tags.Should().HaveCount(1);
+            _source.Tags.Should().Contain(["abc"]);
+            _source.NestedList.Should().HaveCount(1);
+            _source.NestedList[0].Id.Should().Be("UPDATE");
+            _source.NestedList[0].Name.Should().Be("UPDATE");
+
+            IEnumerable<int> x = [];
+            // ReSharper disable once PossibleMultipleEnumeration
+            x.DeepPatch(null);
+            // ReSharper disable once PossibleMultipleEnumeration
+            x.Should().BeEmpty();
+        }
+
+        [Test]
+        public void PatchWorksWithObjects()
+        {
+            var patch = new BigClass { Age = 25, Nested = new BigClassNested { Id = "patched-id", Name = "patched-nested" } };
+            _source.DeepPatch(patch);
+            _source.Id.Should().Be("123");
+            _source.Name.Should().Be("test");
+            _source.Age.Should().Be(25);
+            _source.NextAge.Should().Be(26);
+            _source.Nested.Id.Should().Be("patched-id");
+            _source.Nested.Name.Should().Be("patched-nested");
+            _source.Tags.Should().HaveCount(3);
+            _source.NestedList.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void GetListValueDoesNothingOnInvalidEnumerable()
+        {
+            var method =
+                typeof(ObjectExtensions).GetMethod("GetListValue", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var value = method.Invoke(null, [typeof(string), new Dictionary<string, string>(), new Dictionary<string, string>()]);
+            value.Should().BeNull();
+        }
+
+        private class BigClass
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public int NextAge => Age + 1;
+            public BigClassNested Nested { get; set; }
+            public List<string> Tags { get; set; }
+            public List<BigClassNested> NestedList { get; set; }
+        }
+
+        private class BigClassNested
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
@@ -77,7 +77,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
             {
                 if (model is AuditableModel auditableModel)
                     auditableModel.ModifiedUtc = DateTime.UtcNow;
-                existing.Patch(model, true);
+                existing.PatchModel(model, PatchMode.IgnoreLists);
                 foreach (var prop in listProps)
                 {
                     var itemType = prop.PropertyType.GenericTypeArguments[0];
@@ -118,7 +118,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
                     dbSet.Add(newEntity);
                 else
                 {
-                    existingEntity.Patch(newEntity, true);
+                    existingEntity.PatchModel(newEntity, PatchMode.IgnoreLists);
                     dbSet.Update(existingEntity);
                 }
             }

--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/ModelExtensions.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/ModelExtensions.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Reflection;
 using Dosaic.Hosting.Abstractions.Extensions;
 using Dosaic.Plugins.Persistence.EfCore.Abstractions.Models;
 
@@ -8,44 +5,10 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
 {
     public static class ModelExtensions
     {
-        private static IEnumerable<PropertyInfo> GetPatchProperties<T>() where T : class, IModel
+        public static void PatchModel<T>(this T model, T values, PatchMode patchMode = PatchMode.Full) where T : class, IModel
         {
-            var props = DbModel.GetNestedProperties<T>()
-                .Where(x => x.ParentProperty is null && x.Name != nameof(IModel.Id))
-                .Select(x => x.Property);
-            return props;
-        }
-
-        public static void Patch<T>(this T model, T values, bool ignoreLists = false) where T : class, IModel
-        {
-            if (model is null || values is null) return;
-            foreach (var prop in GetPatchProperties<T>())
-            {
-                var newValue = prop.GetValue(values);
-                var oldValue = prop.GetValue(model);
-                if (newValue is null || newValue.Equals(oldValue))
-                    continue;
-                if (prop.PropertyType.IsGenericType && prop.PropertyType.Implements(typeof(IEnumerable)))
-                {
-                    if (ignoreLists) continue;
-                    newValue = GetListValue(prop, oldValue, newValue);
-                }
-
-                prop.SetValue(model, newValue);
-            }
-        }
-
-        private static object GetListValue(PropertyInfo prop, object oldValue, object newValue)
-        {
-            oldValue ??=
-                Activator.CreateInstance(
-                    typeof(Collection<>).MakeGenericType(prop.PropertyType.GenericTypeArguments[0]));
-            if (oldValue is not IList list || newValue is not IList newList)
-                return null;
-            foreach (var newItem in newList)
-                if (!list.Contains(newItem))
-                    list.Add(newItem);
-            return list;
+            model.DeepPatch(values, patchMode,
+                (_, p) => p.Name != nameof(IModel.Id) && !p.PropertyType.Implements(typeof(IModel)));
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new deep patching mechanism for models and objects, replacing the previous patch logic with a more flexible and extensible approach. The main improvements include the addition of `DeepPatch` and related extension methods, new patching modes, and enhanced handling of lists and nested objects. The changes also update usages and tests to reflect the new API.

### Object patching enhancements

* Added `DeepPatch` extension method in `ObjectExtensions`, supporting deep patching of objects and lists with configurable `PatchMode` flags (Full, IgnoreLists, IgnoreObjects, OverwriteLists). This allows for more granular control over how properties and collections are merged.
* Introduced `EnumExtensions` with an `IsFlagSet` helper to simplify flag checks for patching modes.
* Added `IsEnumerable` extension method in `TypeExtensions` to improve detection of collection types during patching.

### Model patching and usage updates

* Replaced the old `Patch` method in `ModelExtensions` with the new `PatchModel` method, which leverages `DeepPatch` and supports patching modes and filtering of properties (e.g., skipping `Id` and nested models).
* Updated usages in `DbExtensions` to use `PatchModel` with appropriate patching modes, ensuring lists are handled according to the new logic. [[1]](diffhunk://#diff-39f7c2ad972a8f3355a8e4f044e198499fb6cee72b1cd18cb3841c096f4b262bL80-R80) [[2]](diffhunk://#diff-39f7c2ad972a8f3355a8e4f044e198499fb6cee72b1cd18cb3841c096f4b262bL121-R121)

### Testing improvements

* Added comprehensive unit tests for the new patching functionality in `ObjectExtensionsTests`, covering normal property patching, list merging/overwriting, nested objects, and edge cases.
* Updated existing model patching tests to use `PatchModel`, and expanded coverage to include patching of models with owned object properties. [[1]](diffhunk://#diff-7564a456f29697e1163469378cd7758cf515a78740e58cc0219e2b73b93ad15eL19-R18) [[2]](diffhunk://#diff-7564a456f29697e1163469378cd7758cf515a78740e58cc0219e2b73b93ad15eL29-R28) [[3]](diffhunk://#diff-7564a456f29697e1163469378cd7758cf515a78740e58cc0219e2b73b93ad15eL43-R42) [[4]](diffhunk://#diff-7564a456f29697e1163469378cd7758cf515a78740e58cc0219e2b73b93ad15eL53-R52) [[5]](diffhunk://#diff-7564a456f29697e1163469378cd7758cf515a78740e58cc0219e2b73b93ad15eL66-R87)