### PR TITLE
Use NeinLinq instead of Projectables, Update deps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="HangFire" Version="1.8.20" />
     <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.2" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.12" />
+    <PackageVersion Include="NeinLinq.EntityFrameworkCore" Version="7.3.2" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.12.0-beta.1" />
@@ -114,7 +115,6 @@
     <PackageVersion Include="Linq.Expression.Optimizer" Version="1.0.32" />
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageVersion Include="GracefulExpandoObject" Version="1.6.0" />
-    <PackageVersion Include="EntityFrameworkCore.Projectables" Version="4.0.0" />
     <PackageVersion Include="Nanoid" Version="3.1.0" />
     <PackageVersion Include="EntityFrameworkCore.Testing.NSubstitute" Version="9.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,8 +88,8 @@
     <PackageVersion Include="AutoBogus" Version="2.13.1" />
     <PackageVersion Include="NaughtyStrings.Bogus" Version="3.0.0" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
@@ -100,7 +100,7 @@
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="Unleash.Client" Version="5.5.0" />
     <PackageVersion Include="Vogen" Version="8.0.2" />
-    <PackageVersion Include="WireMock.Net" Version="1.8.13" />
+    <PackageVersion Include="WireMock.Net" Version="1.12.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="EzSmb" Version="1.3.10" />
     <PackageVersion Include="Polly" Version="8.6.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.2.0" />
     <PackageVersion Include="Buildalyzer.Workspaces" Version="7.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
@@ -12,11 +12,11 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.2.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.3.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Hangfire" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="HangFire" Version="1.8.20" />
+    <PackageVersion Include="HangFire" Version="1.8.21" />
     <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.2" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.12" />
     <PackageVersion Include="NeinLinq.EntityFrameworkCore" Version="7.3.2" />
@@ -52,36 +52,36 @@
     <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="ODataQueryHelper.Core" Version="1.51.91" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.2.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.7" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.4.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.9" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
     <PackageVersion Include="MongoDBMigrations" Version="2.2.0" />
     <PackageVersion Include="Minio" Version="6.0.5" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.3" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
     <PackageVersion Include="jose-jwt" Version="5.2.0" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Restease" Version="1.6.4" />
@@ -92,32 +92,32 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Allure" Version="1.2.1.1" />
     <PackageVersion Include="TngTech.ArchUnitNET.NUnit" Version="0.12.1" />
     <PackageVersion Include="SSH.NET" Version="2025.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Unleash.Client" Version="5.2.1" />
-    <PackageVersion Include="Vogen" Version="7.0.4" />
+    <PackageVersion Include="Unleash.Client" Version="5.5.0" />
+    <PackageVersion Include="Vogen" Version="8.0.2" />
     <PackageVersion Include="WireMock.Net" Version="1.8.13" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="EzSmb" Version="1.3.10" />
-    <PackageVersion Include="Polly" Version="8.6.2" />
-    <PackageVersion Include="MassTransit" Version="8.5.1" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.5.1" />
+    <PackageVersion Include="Polly" Version="8.6.3" />
+    <PackageVersion Include="MassTransit" Version="8.5.2" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.5.2" />
     <PackageVersion Include="DynamicExpresso.Core" Version="2.19.2" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
-    <PackageVersion Include="Mime-Detective" Version="25.4.25" />
+    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
     <PackageVersion Include="Sqids" Version="3.1.0" />
     <PackageVersion Include="VaultSharp" Version="1.17.5.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageVersion Include="Linq.Expression.Optimizer" Version="1.0.32" />
+    <PackageVersion Include="Linq.Expression.Optimizer" Version="1.0.33" />
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageVersion Include="GracefulExpandoObject" Version="1.6.0" />
     <PackageVersion Include="Nanoid" Version="3.1.0" />
     <PackageVersion Include="EntityFrameworkCore.Testing.NSubstitute" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Dosaic.Plugins.Persistence.EfCore.Abstractions.csproj
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Dosaic.Plugins.Persistence.EfCore.Abstractions.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="NeinLinq.EntityFrameworkCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore"/>
     <PackageReference Include="OpenTelemetry.Extensions.Hosting"/>
-    <PackageReference Include="EntityFrameworkCore.Projectables" />
     <PackageReference Include="GracefulExpandoObject" />
     <PackageReference Include="Linq.Expression.Optimizer" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" />

--- a/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/Dosaic.Plugins.Persistence.EfCore.NpgSql.csproj
+++ b/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/Dosaic.Plugins.Persistence.EfCore.NpgSql.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
-    <PackageReference Include="EntityFrameworkCore.Projectables" />
     <PackageReference Include="Linq.Expression.Optimizer" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" />
 

--- a/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/S3FileStoragePluginTests.cs
+++ b/Plugins/Persistence/S3/test/Dosaic.Plugins.Persistence.S3.Tests/S3FileStoragePluginTests.cs
@@ -67,7 +67,7 @@ namespace Dosaic.Plugins.Persistence.S3.Tests
             sp.GetRequiredService<IFileTypeDefinitionResolver>().Should().NotBeNull();
             sp.GetRequiredService<IFileStorage>().Should().NotBeNull();
             var fileStorage = sp.GetRequiredService<IFileStorage>() as FileStorage;
-            fileStorage!.GetDefinitions(FileType.All).Should().HaveCount(65);
+            fileStorage!.GetDefinitions(FileType.All).Should().HaveCountGreaterThan(1);
 
             var fileStorageSampleBucket = sp.GetRequiredService<IFileStorage<SampleBucket>>();
             fileStorageSampleBucket.Should().NotBeNull();


### PR DESCRIPTION
This pull request updates package dependencies and refactors how Npgsql and Entity Framework Core context configuration is handled, replacing `EntityFrameworkCore.Projectables` with `NeinLinq.EntityFrameworkCore`. It introduces a more flexible configuration pattern for Npgsql context setup and updates related tests accordingly.
It was explicitly maked a breaking change to adjust to the new configuration pattern.

**Dependency updates and replacements:**

* Updated multiple NuGet package versions in `Directory.Packages.props`, including `Microsoft.EntityFrameworkCore.*`, `Microsoft.Extensions.*`, `HangFire`, and others for bug fixes and new features. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R19) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L35-R38) [[3]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L54-R120)
* Removed `EntityFrameworkCore.Projectables` and added `NeinLinq.EntityFrameworkCore` in both `Dosaic.Plugins.Persistence.EfCore.Abstractions.csproj` and `Dosaic.Plugins.Persistence.EfCore.NpgSql.csproj`, reflecting a switch in lambda/rewriting support for EF Core. [[1]](diffhunk://#diff-fb61f6d94b25f498200934264a31ddac0d4ff04868c6d6e86dbe3f8f7a2babf3R12-L14) [[2]](diffhunk://#diff-4b62056ea1e5a9e8fb223aff9e7c1d7a67fed57280f46debfd8765619bab6c8bL10)

**Npgsql context configuration refactor:**

* Replaced the static `ConfigureNpgSqlDatabase` method with an extension method `ConfigureNpgSqlContext` on `DbContextOptionsBuilder`, introducing the `NpgSqlConfiguration` class for fluent configuration of compiled models, data source, context options, and warnings. [[1]](diffhunk://#diff-8149b1d72104a83e11a54364e9a6a48467ce72fd88d0e0594179ae90426ab895L17-R27) [[2]](diffhunk://#diff-8149b1d72104a83e11a54364e9a6a48467ce72fd88d0e0594179ae90426ab895R43-R71) [[3]](diffhunk://#diff-8149b1d72104a83e11a54364e9a6a48467ce72fd88d0e0594179ae90426ab895R84-R113)
* Updated Npgsql context setup to use `WithLambdaInjection()` (from NeinLinq) instead of `UseProjectables()`.

**Test updates:**

* Refactored tests in `ServiceCollectionExtensionsTests.cs` to use the new `ConfigureNpgSqlContext` API and verify the presence of `NeinLinq.RewriteDbContextOptionsExtension` instead of the previous Projectables extension. [[1]](diffhunk://#diff-68183797d83af58e2d214e81586eeb0ecd24a0b5544dc44aa13a0cd9c76648e6L57-R57) [[2]](diffhunk://#diff-68183797d83af58e2d214e81586eeb0ecd24a0b5544dc44aa13a0cd9c76648e6L66-R66) [[3]](diffhunk://#diff-68183797d83af58e2d214e81586eeb0ecd24a0b5544dc44aa13a0cd9c76648e6L83-L86) [[4]](diffhunk://#diff-68183797d83af58e2d214e81586eeb0ecd24a0b5544dc44aa13a0cd9c76648e6L108-R106) [[5]](diffhunk://#diff-68183797d83af58e2d214e81586eeb0ecd24a0b5544dc44aa13a0cd9c76648e6L119-R115)