### PR TITLE
Load types via reflection safly, add test extensions

### DIFF
--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/AssemblyExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/AssemblyExtensions.cs
@@ -4,9 +4,21 @@ namespace Dosaic.Hosting.Abstractions.Extensions
 {
     public static class AssemblyExtensions
     {
+        private static Type[] GetTypesSafe(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch
+            {
+                return [];
+            }
+        }
+
         public static bool HasType(this Assembly assembly, Predicate<Type> typePredicate)
         {
-            return assembly.GetTypes().Any(t => typePredicate(t));
+            return GetTypesSafe(assembly).Any(t => typePredicate(t));
         }
 
         public static IList<Type> GetTypes(this IEnumerable<Assembly> assemblies, Predicate<Type> typePredicate = null)
@@ -16,7 +28,7 @@ namespace Dosaic.Hosting.Abstractions.Extensions
 
         public static IList<Type> GetTypes(this Assembly assembly, Predicate<Type> typePredicate = null)
         {
-            return assembly.GetTypes().Where(x => typePredicate == null || typePredicate(x)).ToList();
+            return GetTypesSafe(assembly).Where(x => typePredicate == null || typePredicate(x)).ToList();
         }
     }
 }

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/TestExtensions.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/TestExtensions.cs
@@ -1,6 +1,3 @@
-using ArchUnitNET.Domain;
-using AutoBogus;
-using Dosaic.Hosting.Abstractions.Extensions;
 using Dosaic.Plugins.Persistence.EfCore.Abstractions.Audit;
 using Dosaic.Plugins.Persistence.EfCore.Abstractions.Database;
 using Dosaic.Plugins.Persistence.EfCore.Abstractions.Models;
@@ -11,20 +8,6 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests
 {
     public static class TestExtensions
     {
-        private static readonly Type[] _types = AppDomain.CurrentDomain.GetAssemblies().GetTypes().ToArray();
-
-        public static Type GetRealType(this Class cls)
-        {
-            return _types.FirstOrDefault(x => x.FullName == cls.FullName);
-        }
-
-        public static T Fake<T>(Action<T> configure = null) where T : class
-        {
-            var result = new AutoFaker<T>().Configure(c => c.WithRecursiveDepth(0)).Generate();
-            configure?.Invoke(result);
-            return result;
-        }
-
         public static T GetModel<T>(Action<T> configure = null) where T : IModel
         {
             var m = Activator.CreateInstance<T>();

--- a/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/ArchitectureExtensions.cs
+++ b/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/ArchitectureExtensions.cs
@@ -1,11 +1,20 @@
 using ArchUnitNET.Domain;
 using ArchUnitNET.Loader;
+using Dosaic.Hosting.Abstractions.Extensions;
 using Assembly = System.Reflection.Assembly;
+using Type = System.Type;
 
 namespace Dosaic.Testing.NUnit.Extensions
 {
     public static class ArchitectureExtensions
     {
+        private static readonly Type[] _types = AppDomain.CurrentDomain.GetAssemblies().GetTypes().ToArray();
+
+        public static Type GetRealType(this Class cls)
+        {
+            return _types.FirstOrDefault(x => x.FullName == cls.FullName);
+        }
+
         public static Architecture FromCurrentAssembly(this ArchLoader archLoader)
         {
             return archLoader.LoadAssembly(Assembly.GetCallingAssembly()).Build();

--- a/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/DataExtensions.cs
+++ b/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/DataExtensions.cs
@@ -1,0 +1,37 @@
+using AutoBogus;
+
+namespace Dosaic.Testing.NUnit.Extensions
+{
+    public static class TestData
+    {
+        public static T Fake<T>(Action<T> configure = null) where T : class
+        {
+            var result = new AutoFaker<T>().Configure(c => c.WithRecursiveDepth(0)).Generate();
+            configure?.Invoke(result);
+            return result;
+        }
+
+        public static T[] FakeMany<T>(int count, Action<T> configure = null) where T : class
+        {
+            var result = new AutoFaker<T>().Configure(c => c.WithRecursiveDepth(0)).Generate(count);
+            foreach (var r in result)
+                configure?.Invoke(r);
+            return result.ToArray();
+        }
+
+        public static T FakeDeep<T>(int depth = 1, Action<T> configure = null) where T : class
+        {
+            var result = new AutoFaker<T>().Configure(c => c.WithRecursiveDepth(depth)).Generate();
+            configure?.Invoke(result);
+            return result;
+        }
+
+        public static T[] FakeDeepMany<T>(int count, int depth = 1, Action<T> configure = null) where T : class
+        {
+            var result = new AutoFaker<T>().Configure(c => c.WithRecursiveDepth(depth)).Generate(count);
+            foreach (var r in result)
+                configure?.Invoke(r);
+            return result.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors and improves type handling and test data generation utilities across several projects. The main changes include making type retrieval from assemblies safer, relocating and consolidating test data generation helpers, and cleaning up unused code.

**Assembly type handling improvements:**

* Added a private `GetTypesSafe` method to `AssemblyExtensions` in `Dosaic.Hosting.Abstractions` to safely retrieve types from assemblies, preventing exceptions from breaking type queries. Updated `HasType` and `GetTypes` methods to use this safer approach. [[1]](diffhunk://#diff-b572a8a0282b56f359008107332af621f694afeb4e3ff822e1a9f9fd7c414646R7-R21) [[2]](diffhunk://#diff-b572a8a0282b56f359008107332af621f694afeb4e3ff822e1a9f9fd7c414646L19-R31)

**Test data generation and architecture utilities:**

* Moved the `Fake` method and related helpers for generating test data using AutoBogus from `TestExtensions.cs` in EfCore.Abstractions tests to a new `TestData` class in `Dosaic.Testing.NUnit.Extensions`, adding methods for generating deep and multiple fakes. [[1]](diffhunk://#diff-8459677fac72fb451916f7793850020651f152faa0abe77fb7de15aa5885697eL14-L27) [[2]](diffhunk://#diff-5f03d8c1f5b512dc635d2ebe8b07a5eb7bbc6b06b9165d73a3c59388e236e170R1-R37)
* Relocated the `GetRealType` helper for mapping ArchUnitNET `Class` objects to real runtime types from EfCore.Abstractions tests to `ArchitectureExtensions` in `Dosaic.Testing.NUnit.Extensions`, ensuring it uses the new safe type retrieval. [[1]](diffhunk://#diff-8459677fac72fb451916f7793850020651f152faa0abe77fb7de15aa5885697eL14-L27) [[2]](diffhunk://#diff-6572e453cde7a6ac951134768bfa9b39263cf5f1ff4b43526c0a0c08091e46aeR3-R17)

**Code cleanup:**

* Removed unused imports and obsolete helper methods from `TestExtensions.cs` in EfCore.Abstractions tests, streamlining the test helper code. (F4b8290fL4R8)