### PR TITLE
Renamed GetTypes to ensure distinction

### DIFF
--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/AssemblyExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/AssemblyExtensions.cs
@@ -5,8 +5,24 @@ namespace Dosaic.Hosting.Abstractions.Extensions
 {
     public static class AssemblyExtensions
     {
+        public static bool HasType(this Assembly assembly, Predicate<Type> typePredicate)
+        {
+            return GetAllTypesSafely(assembly).Any(t => typePredicate(t));
+        }
+
+        public static IList<Type> GetTypesSafely(this IEnumerable<Assembly> assemblies,
+            Predicate<Type> typePredicate = null)
+        {
+            return assemblies.SelectMany(x => x.GetTypesSafely(typePredicate)).ToList();
+        }
+
+        public static IList<Type> GetTypesSafely(this Assembly assembly, Predicate<Type> typePredicate = null)
+        {
+            return GetAllTypesSafely(assembly).Where(x => typePredicate == null || typePredicate(x)).ToList();
+        }
+
         [ExcludeFromCodeCoverage]
-        private static Type[] GetTypesSafe(Assembly assembly)
+        private static Type[] GetAllTypesSafely(Assembly assembly)
         {
             try
             {
@@ -16,21 +32,6 @@ namespace Dosaic.Hosting.Abstractions.Extensions
             {
                 return [];
             }
-        }
-
-        public static bool HasType(this Assembly assembly, Predicate<Type> typePredicate)
-        {
-            return GetTypesSafe(assembly).Any(t => typePredicate(t));
-        }
-
-        public static IList<Type> GetTypes(this IEnumerable<Assembly> assemblies, Predicate<Type> typePredicate = null)
-        {
-            return assemblies.SelectMany(x => x.GetTypes(typePredicate)).ToList();
-        }
-
-        public static IList<Type> GetTypes(this Assembly assembly, Predicate<Type> typePredicate = null)
-        {
-            return GetTypesSafe(assembly).Where(x => typePredicate == null || typePredicate(x)).ToList();
         }
     }
 }

--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/SerializationExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/SerializationExtensions.cs
@@ -121,8 +121,7 @@ namespace Dosaic.Hosting.Abstractions.Extensions
         {
             if (!_kindTypes.TryGetValue(type, out var possibleTypes))
             {
-                var types = AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(x => x.GetTypes()).ToArray();
+                var types = AppDomain.CurrentDomain.GetAssemblies().GetTypesSafely();
                 possibleTypes = types.Where(x => x.IsClass && type.IsAssignableFrom(x)).ToArray();
                 _kindTypes[type] = possibleTypes;
                 foreach (var pt in possibleTypes)
@@ -161,8 +160,7 @@ namespace Dosaic.Hosting.Abstractions.Extensions
         {
             if (_converters.TryGetValue(typeToConvert, out var cachedConverter))
                 return cachedConverter;
-            var types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.GetTypes());
+            var types = AppDomain.CurrentDomain.GetAssemblies().GetTypesSafely();
             var converterType = typeof(KindSpecifierConverter<>).MakeGenericType(typeToConvert);
             var converter = (JsonConverter)Activator.CreateInstance(converterType, [types])!;
             _converters.Add(typeToConvert, converter);

--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/TypeExtensions.cs
@@ -24,13 +24,22 @@ namespace Dosaic.Hosting.Abstractions.Extensions
                 if (currentChild == null)
                     return false;
             }
+
             return false;
         }
+
         public static bool Implements<T>(this Type type) => type.Implements(typeof(T));
-        public static bool HasAttribute<T>(this Type type) where T : Attribute => type.GetCustomAttribute<T>() is not null;
+
+        public static bool HasAttribute<T>(this Type type) where T : Attribute =>
+            type.GetCustomAttribute<T>() is not null;
+
         public static T GetAttribute<T>(this Type type) where T : Attribute => type.GetCustomAttribute<T>();
-        public static IList<T> GetAttributes<T>(this Type type) where T : Attribute => type.GetCustomAttributes<T>().ToList();
+
+        public static IList<T> GetAttributes<T>(this Type type) where T : Attribute =>
+            type.GetCustomAttributes<T>().ToList();
+
         public static bool CanBeInstantiated(this Type type) => !type.IsAbstract && !type.IsInterface;
+
         private static bool HasAnyInterfaces(Type type, Type implementationType)
         {
             return type.GetInterfaces()
@@ -45,12 +54,16 @@ namespace Dosaic.Hosting.Abstractions.Extensions
                     return currentInterface == implementationType;
                 });
         }
-        public static IList<Type> GetAssemblyTypes(this Type t, Predicate<Type> typePredicate = null) => t.Assembly.GetTypes(typePredicate);
+
+        public static IList<Type> GetAssemblyTypesSafely(this Type t, Predicate<Type> typePredicate = null) =>
+            t.Assembly.GetTypesSafely(typePredicate);
+
         public static string GetNormalizedName(this Type type)
         {
             if (!type.IsGenericType) return type.Name;
             var nonGenericTypeName = type.Name.Split('`')[0];
-            if (type.IsGenericTypeDefinition) return $"{nonGenericTypeName}<{new string(',', type.GetGenericArguments().Length - 1)}>";
+            if (type.IsGenericTypeDefinition)
+                return $"{nonGenericTypeName}<{new string(',', type.GetGenericArguments().Length - 1)}>";
             var genericArguments = type.GetGenericArguments();
             return $"{nonGenericTypeName}<{string.Join(", ", genericArguments.Select(GetNormalizedName))}>";
         }

--- a/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/AssemblyExtensionTests.cs
+++ b/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/AssemblyExtensionTests.cs
@@ -10,10 +10,10 @@ namespace Dosaic.Hosting.Abstractions.Tests.Extensions
         [Test]
         public void CanQueryTypesEasily()
         {
-            typeof(AssemblyExtensionTests).GetAssemblyTypes(t => t.Name == nameof(AssemblyExtensionTests))
+            typeof(AssemblyExtensionTests).GetAssemblyTypesSafely(t => t.Name == nameof(AssemblyExtensionTests))
                 .Should().HaveCount(1);
             var x = new List<Assembly> { typeof(AssemblyExtensionTests).Assembly }; ;
-            x.GetTypes(t => t.Name == nameof(AssemblyExtensionTests))
+            x.GetTypesSafely(t => t.Name == nameof(AssemblyExtensionTests))
                 .Should().HaveCount(1);
         }
     }

--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbModel.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbModel.cs
@@ -14,7 +14,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
         public static PropertyInfo[] GetProperties<T>() => GetProperties(typeof(T));
         public static Type GetModelByName(Type dbContextType, string modelName) => GetModels(dbContextType)[modelName.ToLowerInvariant()];
 
-        public static IDictionary<string, Type> GetModels(Type dbContextType) => dbContextType.GetAssemblyTypes()
+        public static IDictionary<string, Type> GetModels(Type dbContextType) => dbContextType.GetAssemblyTypesSafely()
             .Where(x => x is { IsClass: true, IsAbstract: false, IsGenericType: false } && x.Implements<IModel>())
             .ToDictionary(x => x.Name.ToLowerInvariant(), x => x);
 

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/EfCorePluginTests.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/EfCorePluginTests.cs
@@ -33,7 +33,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests
         {
             _implementationResolver = Substitute.For<IImplementationResolver>();
             _implementationResolver.FindTypes().Returns([
-                .. typeof(EfCorePlugin).GetAssemblyTypes(), .. typeof(EfCorePluginTests).GetAssemblyTypes()
+                .. typeof(EfCorePlugin).GetAssemblyTypesSafely(), .. typeof(EfCorePluginTests).GetAssemblyTypesSafely()
             ]);
             _implementationResolver.FindAssemblies()
                 .Returns([typeof(EfCorePlugin).Assembly, typeof(TestAggregate).Assembly]);

--- a/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/PostgresEnumExtensions.cs
+++ b/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/PostgresEnumExtensions.cs
@@ -12,8 +12,8 @@ namespace Dosaic.Plugins.Persistence.EfCore.NpgSql
         private static readonly NpgsqlSnakeCaseNameTranslator _translator = new();
 
         private static HashSet<Type> GetEnumTypes(Type modelType) =>
-            modelType.GetAssemblyTypes(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>())
-                .Union(typeof(EfCoreDbContext).GetAssemblyTypes(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>()))
+            modelType.GetAssemblyTypesSafely(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>())
+                .Union(typeof(EfCoreDbContext).GetAssemblyTypesSafely(x => x.IsEnum && x.HasAttribute<DbEnumAttribute>()))
                 .ToHashSet();
 
         public static void MapDbEnums<TDbContext>(this ModelBuilder builder)

--- a/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/ArchitectureExtensions.cs
+++ b/Testing/NUnit/src/Dosaic.Testing.NUnit/Extensions/ArchitectureExtensions.cs
@@ -8,7 +8,7 @@ namespace Dosaic.Testing.NUnit.Extensions
 {
     public static class ArchitectureExtensions
     {
-        private static readonly Type[] _types = AppDomain.CurrentDomain.GetAssemblies().GetTypes().ToArray();
+        private static readonly Type[] _types = AppDomain.CurrentDomain.GetAssemblies().GetTypesSafely().ToArray();
 
         public static Type GetRealType(this Class cls)
         {


### PR DESCRIPTION
This pull request focuses on improving the safety and robustness of type discovery across assemblies by introducing new extension methods that safely handle exceptions thrown during reflection. It updates usages throughout the codebase to utilize these safer methods, ensuring that type queries do not fail due to problematic assemblies or types. The changes also include some minor refactoring for consistency and clarity in extension methods.

**Type discovery and safety improvements:**

* Introduced `GetTypesSafely` and `GetAllTypesSafely` extension methods in `AssemblyExtensions`, replacing direct usage of `GetTypes` to prevent exceptions from breaking type discovery. These methods are now used throughout the codebase for querying types in assemblies and collections of assemblies.
* Updated usages in serialization (`SerializationExtensions.cs`) to use `GetTypesSafely` for both YAML and JSON converter type discovery, increasing reliability when scanning loaded assemblies. [[1]](diffhunk://#diff-6a252e9b882600b343d5fab504cd7c3a7d96c015529dd6198d3def1598690c5cL124-R124) [[2]](diffhunk://#diff-6a252e9b882600b343d5fab504cd7c3a7d96c015529dd6198d3def1598690c5cL164-R163)
* Changed type discovery in test and plugin code (`AssemblyExtensionTests.cs`, `EfCorePluginTests.cs`, `DbModel.cs`, `PostgresEnumExtensions.cs`, and `ArchitectureExtensions.cs`) to use the new safe methods, ensuring tests and plugin initialization are robust against reflection errors. [[1]](diffhunk://#diff-d50c7d1c24a4f587afa985626d25112339d8403ca8cb47a408ef21dc844b7b88L13-R16) [[2]](diffhunk://#diff-53978e379d9bc604f4f4aab8f98d78489aca2545a52ff0d77346257bd262aaacL36-R36) [[3]](diffhunk://#diff-74bd1620215d7b0baf86cf864dabb4f155d91264bcc543e71231ae3cab7adf54L17-R17) [[4]](diffhunk://#diff-3c6b9cf46419c75d820bac4d5f0bd0b6e90e299121b42bca5e1216111cbd1495L15-R16) [[5]](diffhunk://#diff-6572e453cde7a6ac951134768bfa9b39263cf5f1ff4b43526c0a0c08091e46aeL11-R11)

**Extension method refactoring and clarity:**

* Added `GetAssemblyTypesSafely` to `TypeExtensions` and updated usages to improve naming consistency and ensure all type queries are routed through the safer methods. [[1]](diffhunk://#diff-729a0fefaf385000ff8d9252f73b1bab6ef95e98345ecc57d7b11bb5199282b8L48-R66) [[2]](diffhunk://#diff-74bd1620215d7b0baf86cf864dabb4f155d91264bcc543e71231ae3cab7adf54L17-R17) [[3]](diffhunk://#diff-53978e379d9bc604f4f4aab8f98d78489aca2545a52ff0d77346257bd262aaacL36-R36) [[4]](diffhunk://#diff-3c6b9cf46419c75d820bac4d5f0bd0b6e90e299121b42bca5e1216111cbd1495L15-R16)
* Minor formatting and clarity improvements in `TypeExtensions` for attribute and instantiation checks, improving code readability.