### PR TITLE
allow to specify that each postgres migration is done on its own

### DIFF
--- a/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/ServiceCollectionExtensions.cs
+++ b/Plugins/Persistence/EfCore/NpgSql/src/Dosaic.Plugins.Persistence.EfCore.NpgSql/ServiceCollectionExtensions.cs
@@ -11,15 +11,10 @@ namespace Dosaic.Plugins.Persistence.EfCore.NpgSql
 {
     public static class ServiceCollectionExtensions
     {
-        public static void AddNpgsqlDbMigratorService<TDbContext>(this IServiceCollection serviceCollection, bool migrateAllAtOnce = true)
+        public static void AddNpgsqlDbMigratorService<TDbContext>(this IServiceCollection serviceCollection)
             where TDbContext : DbContext
         {
-            serviceCollection.AddHostedService(sp =>
-            {
-                var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-                var logger = sp.GetRequiredService<ILogger<NpgsqlDbMigratorService<TDbContext>>>();
-                return new NpgsqlDbMigratorService<TDbContext>(scopeFactory, logger, migrateAllAtOnce);
-            });
+            serviceCollection.AddHostedService<NpgsqlDbMigratorService<TDbContext>>();
         }
 
         public static void ConfigureNpgSqlContext<TDbContext>(this DbContextOptionsBuilder builder,

--- a/Plugins/Persistence/EfCore/NpgSql/test/Dosaic.Plugins.Persistence.EfCore.NpgSql.Tests/ServiceCollectionExtensionsTests.cs
+++ b/Plugins/Persistence/EfCore/NpgSql/test/Dosaic.Plugins.Persistence.EfCore.NpgSql.Tests/ServiceCollectionExtensionsTests.cs
@@ -171,17 +171,14 @@ namespace Dosaic.Plugins.Persistence.EfCore.NpgSql.Tests
         {
             var services = TestingDefaults.ServiceCollection();
 
-            services.AddNpgsqlDbMigratorService<TestEfCoreDb>(false);
+            services.AddNpgsqlDbMigratorService<TestEfCoreDb>();
 
             var serviceDescriptor = services.FirstOrDefault(sd =>
                 sd.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService)
-                && sd.ImplementationFactory!.GetType() == typeof(Func<IServiceProvider, NpgsqlDbMigratorService<TestEfCoreDb>>));
+                && sd.ImplementationType == typeof(NpgsqlDbMigratorService<TestEfCoreDb>));
 
             serviceDescriptor.Should().NotBeNull();
             serviceDescriptor?.Lifetime.Should().Be(ServiceLifetime.Singleton);
-
-            var migService = serviceDescriptor!.ImplementationFactory!(services.BuildServiceProvider());
-            migService.Should().BeOfType<NpgsqlDbMigratorService<TestEfCoreDb>>();
         }
 
         [Test]


### PR DESCRIPTION
This pull request enhances the `NpgsqlDbMigratorService` to support two migration strategies: applying all pending migrations at once or applying them one at a time. The service registration and related tests are updated to accommodate this new flexibility.

**Migration strategy improvements:**

* Added a `migrateAllAtOnce` parameter to the `NpgsqlDbMigratorService` constructor, enabling control over whether all migrations are applied together or individually. The migration logic in `ExecuteAsync` now checks this flag and applies migrations accordingly, logging each step. [[1]](diffhunk://#diff-c0f87e564d5dfea4e41a4683badcd396eaeac162412cce6bfb44878f74edd70bL12-R12) [[2]](diffhunk://#diff-c0f87e564d5dfea4e41a4683badcd396eaeac162412cce6bfb44878f74edd70bR24-R37)

**Service registration updates:**

* Updated the `AddNpgsqlDbMigratorService` extension method to accept the `migrateAllAtOnce` parameter and register the migrator service using a factory that passes this argument.

**Testing enhancements:**

* Modified the test `AddNpgsqlDbMigratorService_ShouldRegisterNpgsqlDbMigratorService` to verify the new registration pattern and ensure the correct migrator service is registered with the specified migration strategy.