### PR TITLE
adjust owned object patching

### DIFF
--- a/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/ObjectExtensions.cs
+++ b/Hosting/Abstractions/src/Dosaic.Hosting.Abstractions/Extensions/ObjectExtensions.cs
@@ -65,7 +65,7 @@ namespace Dosaic.Hosting.Abstractions.Extensions
                 else if (isObject)
                 {
                     if (ignoreObjects) continue;
-                    newValue = DeepPatchInternal(oldValue, newValue, mode, filter);
+                    newValue = DeepPatchInternal(oldValue ?? Activator.CreateInstance(prop.PropertyType), newValue, mode, filter);
                 }
                 prop.SetValue(value, newValue);
             }

--- a/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/Hosting/Abstractions/test/Dosaic.Hosting.Abstractions.Tests/Extensions/ObjectExtensionsTests.cs
@@ -106,6 +106,29 @@ namespace Dosaic.Hosting.Abstractions.Tests.Extensions
         }
 
         [Test]
+        public void PatchPreservesObjectReferenceIdentity()
+        {
+            var originalNested = _source.Nested;
+            var patch = new BigClass { Nested = new BigClassNested { Id = "patched-id", Name = "patched-nested" } };
+            _source.DeepPatch(patch);
+            ReferenceEquals(_source.Nested, originalNested).Should().BeTrue();
+            _source.Nested.Id.Should().Be("patched-id");
+            _source.Nested.Name.Should().Be("patched-nested");
+        }
+
+        [Test]
+        public void PatchHandlesNullOldValueForObject()
+        {
+            _source.Nested = null;
+            var patch = new BigClass { Nested = new BigClassNested { Id = "new-id", Name = "new-name" } };
+            _source.DeepPatch(patch);
+            _source.Nested.Should().NotBeNull();
+            ReferenceEquals(_source.Nested, patch.Nested).Should().BeFalse();
+            _source.Nested.Id.Should().Be("new-id");
+            _source.Nested.Name.Should().Be("new-name");
+        }
+
+        [Test]
         public void GetListValueDoesNothingOnInvalidEnumerable()
         {
             var method =

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphTests.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphTests.cs
@@ -96,5 +96,38 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
             _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Deleted);
             _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Modified);
         }
+
+        [Test]
+        public async Task UpdateGraphPreservesOwnedTypeReference()
+        {
+            var model = new TestAuditModel
+            {
+                Id = "1",
+                Name = "test",
+                Subs =
+                [
+                    new SubTestModel
+                    {
+                        Id = "11",
+                        DeepName = "11",
+                        OwnedInfo = new SubTestOwnedInfo { InfoKey = "key1", InfoValue = "val1" }
+                    }
+                ],
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = "test",
+                ModifiedBy = "test"
+            };
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.Entry(model).State = EntityState.Detached;
+
+            model.Subs.Single().OwnedInfo = new SubTestOwnedInfo { InfoKey = "key1-updated", InfoValue = "val1-updated" };
+
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+
+            var patchedSub = _db.ChangeTracker.Entries<SubTestModel>().Single().Entity;
+            patchedSub.OwnedInfo.InfoKey.Should().Be("key1-updated");
+            patchedSub.OwnedInfo.InfoValue.Should().Be("val1-updated");
+        }
     }
 }

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/TestModel.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/TestModel.cs
@@ -55,10 +55,17 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests
         public virtual ICollection<SubTestModel> Subs { get; set; } = null!;
     }
 
+    public class SubTestOwnedInfo
+    {
+        public string InfoKey { get; set; }
+        public string InfoValue { get; set; }
+    }
+
     [DbNanoIdPrimaryKey(NanoIdConfig.Lengths.NoLookAlikeDigitsAndLetters.L2)]
     public class SubTestModel : Model
     {
         public required string DeepName { get; set; }
+        public SubTestOwnedInfo OwnedInfo { get; set; }
     }
 
     [DbNanoIdPrimaryKey(NanoIdConfig.Lengths.NoLookAlikeDigitsAndLetters.L2)]
@@ -104,6 +111,11 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests
             builder.ToTable(nameof(SubTestModel), "test");
             builder.HasKey(x => x.Id);
             builder.Property(x => x.DeepName);
+            builder.OwnsOne(x => x.OwnedInfo, owned =>
+            {
+                owned.Property(x => x.InfoKey);
+                owned.Property(x => x.InfoValue);
+            });
         }
     }
 


### PR DESCRIPTION
This pull request introduces improvements to object patching and owned type handling, with a focus on preserving reference identity and supporting null values. It also adds new tests and extends the test models to cover these scenarios.

### Object patching improvements

* Updated `DeepPatchInternal` in `ObjectExtensions.cs` to instantiate a new object if the existing value is null, ensuring patching works when the target property is initially null.

### Testing enhancements

* Added tests to `ObjectExtensionsTests.cs` to verify that object reference identity is preserved during patching and that patching works correctly when the old value is null.
* Added a test to `DbExtensionsGraphTests.cs` to ensure that updating an entity graph with owned types preserves the reference and correctly updates the owned type's properties.

### Model and configuration updates

* Introduced the `SubTestOwnedInfo` class and added an `OwnedInfo` property to `SubTestModel` to support owned type testing.
* Configured `SubTestModel` in the model builder to own the `OwnedInfo` property, mapping its fields as owned properties.