### PR TITLE
UpdateGraph EntityStates

### DIFF
--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
@@ -119,7 +119,10 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
                 else
                 {
                     existingEntity.PatchModel(newEntity, PatchMode.IgnoreLists);
-                    dbSet.Update(existingEntity);
+                    var dbContext = (DbContext)db;
+                    var entry = dbContext.Entry(existingEntity);
+                    if (entry.State == EntityState.Detached)
+                        dbSet.Update(existingEntity);
                 }
             }
         }

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphTests.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphTests.cs
@@ -1,4 +1,5 @@
 using Dosaic.Extensions.NanoIds;
+using Dosaic.Hosting.Abstractions.Extensions;
 using Dosaic.Plugins.Persistence.EfCore.Abstractions.Database;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +8,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
 
     using System;
     using System.Linq;
+    using System.Reflection;
     using AwesomeAssertions;
     using NUnit.Framework;
 
@@ -74,7 +76,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
             model.Subs.First().DeepName = "Changed";
             await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
             _db.ChangeTracker.Entries<TestAuditModel>().Single().State.Should().Be(EntityState.Modified);
-            _db.ChangeTracker.Entries<SubTestModel>().Should().AllSatisfy(x => x.State.Should().Be(EntityState.Modified));
+            _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Modified);
             model.ModifiedUtc.Should().BeWithin(TimeSpan.FromSeconds(1));
             model.ModifiedBy.Should().Be(new NanoId("test"));
             model.Subs.Add(new SubTestModel { Id = "33", DeepName = "33" });
@@ -94,7 +96,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
             await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
             _db.ChangeTracker.Entries<TestAuditModel>().Single().State.Should().Be(EntityState.Modified);
             _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Deleted);
-            _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Modified);
+            _db.ChangeTracker.Entries<SubTestModel>().Should().Contain(x => x.State == EntityState.Unchanged);
         }
 
         [Test]
@@ -128,6 +130,32 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
             var patchedSub = _db.ChangeTracker.Entries<SubTestModel>().Single().Entity;
             patchedSub.OwnedInfo.InfoKey.Should().Be("key1-updated");
             patchedSub.OwnedInfo.InfoValue.Should().Be("val1-updated");
+        }
+
+        [Test]
+        public async Task UpsertMultipleAttachesDetachedEntities()
+        {
+            var model = GetModel();
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+
+            var sub = model.Subs.First();
+            _db.Entry(sub).State = EntityState.Detached;
+            _db.Entry(sub).State.Should().Be(EntityState.Detached);
+
+            var updatedSub = new SubTestModel { Id = sub.Id, DeepName = "Updated" };
+            ICollection<SubTestModel> currentEntities = [sub];
+            ICollection<SubTestModel> newEntities = [sub];
+            sub.PatchModel(updatedSub, PatchMode.IgnoreLists);
+
+            var upsertMethod = typeof(DbExtensions)
+                .GetMethod("UpsertMultiple", BindingFlags.Static | BindingFlags.NonPublic)!
+                .MakeGenericMethod(typeof(SubTestModel));
+            upsertMethod.Invoke(null, [_db, currentEntities, newEntities]);
+
+            var entry = _db.Entry(sub);
+            entry.State.Should().Be(EntityState.Modified);
+            entry.Entity.DeepName.Should().Be("Updated");
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the handling of entity state in the `UpsertMultiple` method and expands test coverage to ensure correct behavior with detached entities. It also makes minor improvements to test assertions and adds necessary using directives.

**Entity state management improvements:**

* Modified `UpsertMultiple<T>` in `DbExtensions.cs` to check if `existingEntity` is detached and call `Update` on the `DbSet` if necessary, ensuring that detached entities are properly tracked and updated.

**Test improvements and coverage:**

* Added a new test `UpsertMultipleAttachesDetachedEntities` to `DbExtensionsGraphTests.cs` to verify that detached entities are correctly attached and updated when using `UpsertMultiple`.
* Improved assertions in `UpdateGraphCanModify` and `UpdateGraphCanDelete` to check for the presence of modified and unchanged states, making the tests more accurate and less restrictive. [[1]](diffhunk://#diff-1bc966d8aa9f8f536cb157bda5d363096ee3035e7867a00829c1d685422136c4L77-R79) [[2]](diffhunk://#diff-1bc966d8aa9f8f536cb157bda5d363096ee3035e7867a00829c1d685422136c4L97-R99)

**Test utilities and imports:**

* Added missing using directives in `DbExtensionsGraphTests.cs` for `Dosaic.Hosting.Abstractions.Extensions` and `System.Reflection` to support new test logic. [[1]](diffhunk://#diff-1bc966d8aa9f8f536cb157bda5d363096ee3035e7867a00829c1d685422136c4R2) [[2]](diffhunk://#diff-1bc966d8aa9f8f536cb157bda5d363096ee3035e7867a00829c1d685422136c4R11)