### PR TITLE
Add int tests, adjust UpdateGraph

### DIFF
--- a/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/src/Dosaic.Plugins.Persistence.EfCore.Abstractions/Database/DbExtensions.cs
@@ -78,6 +78,7 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
                 if (model is AuditableModel auditableModel)
                     auditableModel.ModifiedUtc = DateTime.UtcNow;
                 existing.PatchModel(model, PatchMode.IgnoreLists);
+                SyncOwnedEntities((DbContext)db, existing, model);
                 foreach (var prop in listProps)
                 {
                     var itemType = prop.PropertyType.GenericTypeArguments[0];
@@ -105,25 +106,44 @@ namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Database
             currentEntities ??= new HashSet<T>();
             newEntities ??= new HashSet<T>();
             var dbSet = db.Get<T>();
+            var newIds = newEntities.Select(x => x.Id).ToHashSet();
             var entitiesToRemove = currentEntities
-                .Where(current => !newEntities.Contains(current));
+                .Where(current => !newIds.Contains(current.Id))
+                .ToList();
             foreach (var entity in entitiesToRemove)
                 dbSet.Remove(entity);
 
             foreach (var newEntity in newEntities)
             {
-                var existingEntity = currentEntities.FirstOrDefault(current => current?.Equals(newEntity) ?? false);
+                var existingEntity = currentEntities.FirstOrDefault(current => current.Id == newEntity.Id);
 
                 if (existingEntity is null)
-                    dbSet.Add(newEntity);
+                    currentEntities.Add(newEntity);
                 else
                 {
                     existingEntity.PatchModel(newEntity, PatchMode.IgnoreLists);
                     var dbContext = (DbContext)db;
+                    SyncOwnedEntities(dbContext, existingEntity, newEntity);
                     var entry = dbContext.Entry(existingEntity);
                     if (entry.State == EntityState.Detached)
                         dbSet.Update(existingEntity);
                 }
+            }
+        }
+
+        private static void SyncOwnedEntities<T>(DbContext dbContext, T existingEntity, T newEntity)
+            where T : class
+        {
+            var entry = dbContext.Entry(existingEntity);
+            foreach (var nav in entry.Navigations)
+            {
+                if (!nav.Metadata.TargetEntityType.IsOwned()) continue;
+                var newOwnedValue = typeof(T).GetProperty(nav.Metadata.Name)?.GetValue(newEntity);
+                if (newOwnedValue == null) continue;
+                if (nav.CurrentValue != null)
+                    dbContext.Entry(nav.CurrentValue).CurrentValues.SetValues(newOwnedValue);
+                else
+                    nav.CurrentValue = newOwnedValue;
             }
         }
     }

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphPostgresTests.cs
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Database/DbExtensionsGraphPostgresTests.cs
@@ -1,0 +1,235 @@
+using Dosaic.Plugins.Persistence.EfCore.Abstractions.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.Database
+{
+    using System;
+    using System.Linq;
+    using AwesomeAssertions;
+    using NUnit.Framework;
+
+    [Explicit]
+    public class DbExtensionsGraphPostgresTests
+    {
+        public class PostgresTestDb(DbContextOptions<EfCoreDbContext> options) : EfCoreDbContext(options)
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.HasDefaultSchema("public");
+
+                modelBuilder.Entity<TestAuditModel>(b =>
+                {
+                    b.ToTable("test_audit_model");
+                    b.HasKey(x => x.Id);
+                    b.Property(x => x.Id).HasMaxLength(10);
+                    b.Property(x => x.Name);
+                    b.HasMany(x => x.Subs).WithOne();
+                });
+
+                modelBuilder.Entity<SubTestModel>(b =>
+                {
+                    b.ToTable("sub_test_model");
+                    b.HasKey(x => x.Id);
+                    b.Property(x => x.Id).HasMaxLength(10);
+                    b.Property(x => x.DeepName);
+                    b.OwnsOne(x => x.OwnedInfo, owned =>
+                    {
+                        owned.Property(x => x.InfoKey).HasColumnName("owned_info_key");
+                        owned.Property(x => x.InfoValue).HasColumnName("owned_info_value");
+                    });
+                });
+
+                base.OnModelCreating(modelBuilder);
+            }
+        }
+
+        private PostgresTestDb _db;
+
+        [SetUp]
+        public void Up()
+        {
+            var options = new DbContextOptionsBuilder<EfCoreDbContext>()
+                .UseNpgsql("Host=localhost;Port=5432;Database=dosaic_test;Username=postgres;Password=postgres")
+                .Options;
+            _db = new PostgresTestDb(options);
+            _db.Database.EnsureDeleted();
+            _db.Database.EnsureCreated();
+        }
+
+        [TearDown]
+        public void Down()
+        {
+            _db?.Database.EnsureDeleted();
+            _db?.Dispose();
+        }
+
+        private static TestAuditModel GetModelWithOwnedInfo() => new()
+        {
+            Id = "1",
+            Name = "test",
+            Subs =
+            [
+                new SubTestModel
+                {
+                    Id = "11",
+                    DeepName = "11",
+                    OwnedInfo = new SubTestOwnedInfo { InfoKey = "key1", InfoValue = "val1" }
+                },
+                new SubTestModel
+                {
+                    Id = "12",
+                    DeepName = "12",
+                    OwnedInfo = new SubTestOwnedInfo { InfoKey = "key2", InfoValue = "val2" }
+                }
+            ],
+            CreatedUtc = DateTime.UtcNow,
+            CreatedBy = "test",
+            ModifiedBy = "test"
+        };
+
+        [Test]
+        public async Task UpdateGraphCanInsertWithOwnedEntities()
+        {
+            var model = GetModelWithOwnedInfo();
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+
+            _db.ChangeTracker.Clear();
+            var loaded = await _db.Get<TestAuditModel>()
+                .Include(x => x.Subs)
+                .SingleAsync(x => x.Id == "1");
+            loaded.Subs.Should().HaveCount(2);
+            loaded.Subs.Single(s => s.Id == "11").OwnedInfo.InfoKey.Should().Be("key1");
+            loaded.Subs.Single(s => s.Id == "12").OwnedInfo.InfoKey.Should().Be("key2");
+        }
+
+        [Test]
+        public async Task UpdateGraphCanModifyOwnedEntityOnSub()
+        {
+            var model = GetModelWithOwnedInfo();
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            model.Subs.Single(s => s.Id == "11").OwnedInfo =
+                new SubTestOwnedInfo { InfoKey = "key1-updated", InfoValue = "val1-updated" };
+
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+
+            _db.ChangeTracker.Clear();
+            var loaded = await _db.Get<SubTestModel>().SingleAsync(x => x.Id == "11");
+            loaded.OwnedInfo.InfoKey.Should().Be("key1-updated");
+            loaded.OwnedInfo.InfoValue.Should().Be("val1-updated");
+        }
+
+        [Test]
+        public async Task UpdateGraphCanModifyOwnedEntityFromNullToValue()
+        {
+            var model = new TestAuditModel
+            {
+                Id = "1",
+                Name = "test",
+                Subs =
+                [
+                    new SubTestModel { Id = "11", DeepName = "11", OwnedInfo = null }
+                ],
+                CreatedUtc = DateTime.UtcNow,
+                CreatedBy = "test",
+                ModifiedBy = "test"
+            };
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            model.Subs.Single().OwnedInfo = new SubTestOwnedInfo { InfoKey = "newKey", InfoValue = "newVal" };
+
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+
+            _db.ChangeTracker.Clear();
+            var loaded = await _db.Get<SubTestModel>().SingleAsync(x => x.Id == "11");
+            loaded.OwnedInfo.InfoKey.Should().Be("newKey");
+            loaded.OwnedInfo.InfoValue.Should().Be("newVal");
+        }
+
+        [Test]
+        public async Task UpdateGraphCanAddAndRemoveSubsWithOwnedEntities()
+        {
+            var model = GetModelWithOwnedInfo();
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            model.Subs = [
+                model.Subs.Single(s => s.Id == "11"),
+                new SubTestModel
+                {
+                    Id = "13",
+                    DeepName = "13",
+                    OwnedInfo = new SubTestOwnedInfo { InfoKey = "key3", InfoValue = "val3" }
+                }
+            ];
+
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+
+            _db.ChangeTracker.Clear();
+            var loaded = await _db.Get<TestAuditModel>()
+                .Include(x => x.Subs)
+                .SingleAsync(x => x.Id == "1");
+            loaded.Subs.Should().HaveCount(2);
+            loaded.Subs.Should().Contain(s => s.Id == "11");
+            loaded.Subs.Should().Contain(s => s.Id == "13");
+            loaded.Subs.Should().NotContain(s => s.Id == "12");
+            loaded.Subs.Single(s => s.Id == "13").OwnedInfo.InfoKey.Should().Be("key3");
+        }
+
+        [Test]
+        public async Task UpdateGraphPreservesUnchangedOwnedEntity()
+        {
+            var model = GetModelWithOwnedInfo();
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            model.Subs.Single(s => s.Id == "11").DeepName = "11-updated";
+
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+
+            _db.ChangeTracker.Clear();
+            var loaded = await _db.Get<SubTestModel>().SingleAsync(x => x.Id == "11");
+            loaded.DeepName.Should().Be("11-updated");
+            loaded.OwnedInfo.InfoKey.Should().Be("key1");
+            loaded.OwnedInfo.InfoValue.Should().Be("val1");
+        }
+
+        [Test]
+        public async Task UpdateGraphMultipleRoundTripsWithOwnedEntities()
+        {
+            var model = GetModelWithOwnedInfo();
+            _db.Add(model);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            model.Subs.Single(s => s.Id == "11").OwnedInfo =
+                new SubTestOwnedInfo { InfoKey = "round1", InfoValue = "round1" };
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            var loaded = await _db.Get<SubTestModel>().SingleAsync(x => x.Id == "11");
+            loaded.OwnedInfo.InfoKey.Should().Be("round1");
+
+            model.Subs.Single(s => s.Id == "11").OwnedInfo =
+                new SubTestOwnedInfo { InfoKey = "round2", InfoValue = "round2" };
+            await _db.UpdateGraphAsync(model, m => m.Id == model.Id);
+            await _db.SaveChangesAsync();
+            _db.ChangeTracker.Clear();
+
+            loaded = await _db.Get<SubTestModel>().SingleAsync(x => x.Id == "11");
+            loaded.OwnedInfo.InfoKey.Should().Be("round2");
+        }
+    }
+}

--- a/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.csproj
+++ b/Plugins/Persistence/EfCore/Abstractions/test/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests/Dosaic.Plugins.Persistence.EfCore.Abstractions.Tests.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
       <PackageReference Include="EntityFrameworkCore.Testing.NSubstitute"/>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request enhances the handling of owned entities in the Entity Framework Core persistence layer, ensuring that updates, inserts, and deletions involving owned types are correctly synchronized. It introduces a robust synchronization method for owned entities, refines entity comparison logic, and adds comprehensive integration tests for PostgreSQL to verify these behaviors.

**Enhancements to owned entity synchronization:**

* Added the `SyncOwnedEntities` helper method to ensure owned entity values are updated correctly during graph updates and upserts in `DbExtensions.cs`. This method is now called in both `UpdateGraphAsync` and `UpsertMultiple`, ensuring owned entities are properly set or updated when the parent entity is modified. [[1]](diffhunk://#diff-39f7c2ad972a8f3355a8e4f044e198499fb6cee72b1cd18cb3841c096f4b262bR81) [[2]](diffhunk://#diff-39f7c2ad972a8f3355a8e4f044e198499fb6cee72b1cd18cb3841c096f4b262bR109-R148)

**Improvements to upsert logic:**

* Changed the logic in `UpsertMultiple` to compare entities by their `Id` property instead of using equality, ensuring correct detection of removed or updated entities. Now, new entities are added directly to the current set, and owned entity synchronization is performed during updates.

**Testing and validation:**

* Added a new test suite `DbExtensionsGraphPostgresTests.cs` with multiple integration tests using PostgreSQL to verify that owned entities are correctly inserted, updated, preserved, and removed as part of graph updates. These tests cover edge cases such as modifying owned entities from null to value, round-trip updates, and collection changes.
* Added the `Npgsql.EntityFrameworkCore.PostgreSQL` package reference to the test project to enable PostgreSQL integration testing.