### PR TITLE
qurom queues, middleware order

### DIFF
--- a/Plugins/Messaging/MassTransit/README.md
+++ b/Plugins/Messaging/MassTransit/README.md
@@ -37,6 +37,9 @@ messageBus:
   circuitBreakerTripThreshold: 10
   circuitBreakerActiveThreshold: 5
   circuitBreakerResetIntervalSeconds: 60
+  useQuorumQueues: false
+  quorumQueueReplicationFactor: null
+  deliveryLimit: null
 ```
 
 | Property | Type | Default | Description |
@@ -58,6 +61,9 @@ messageBus:
 | `circuitBreakerTripThreshold` | `int` | `10` | Percentage of failed attempts that trips the circuit breaker (0–100) |
 | `circuitBreakerActiveThreshold` | `int` | `5` | Minimum number of attempts before the circuit breaker can trip |
 | `circuitBreakerResetIntervalSeconds` | `int` | `60` | Duration (seconds) the circuit stays open before resetting |
+| `useQuorumQueues` | `bool` | `false` | Enable RabbitMQ quorum queues for all consumers |
+| `quorumQueueReplicationFactor` | `int?` | `null` | Replication factor for quorum queues (when `null`, uses RabbitMQ default) |
+| `deliveryLimit` | `int?` | `null` | Sets `x-delivery-limit` queue argument on quorum queues — controls how many times a message can be redelivered before being dead-lettered |
 
 > **Note:** When `useInMemory` is `true`, all RabbitMQ settings are ignored.
 
@@ -142,6 +148,38 @@ public class ImportShipmentConsumer : IMessageConsumer<EntityChange<ImportShipme
 ```
 
 When `[ConsumerConcurrency]` is set, `PrefetchCount` is automatically aligned to the concurrency limit (unless overridden in config).
+
+### Quorum Queues
+
+RabbitMQ [quorum queues](https://www.rabbitmq.com/docs/quorum-queues) can be enabled globally via configuration or per-consumer via the `[QuorumQueue]` attribute.
+
+**Global** — enable for all consumers:
+
+```yaml
+messageBus:
+  host: rabbitmq://localhost
+  username: guest
+  password: guest
+  useQuorumQueues: true
+  quorumQueueReplicationFactor: 3
+  deliveryLimit: 5
+```
+
+**Per-consumer** — enable (or override the replication factor) for a specific consumer:
+
+```csharp
+using Dosaic.Plugins.Messaging.MassTransit;
+
+[QuorumQueue(3)]
+public class MyConsumer : MessageConsumer<MyMessage>
+{
+    // This consumer's queue will use quorum queues with replication factor 3
+}
+```
+
+`[QuorumQueue]` without arguments enables quorum queues with the RabbitMQ default replication factor. When both global configuration and the attribute are present, the attribute takes precedence.
+
+`DeliveryLimit` only applies to quorum queues and is ignored for classic queues.
 
 ### Per-Consumer Timeout
 
@@ -265,6 +303,7 @@ public class MyBusConfigurator : IMessageBusConfigurator
 - **Built-in retry** — configurable immediate retry (`useRetry`, `maxRetryCount`, `retryDelaySeconds`) and delayed redelivery (`maxRedeliveryCount`, `redeliveryDelaySeconds`) using MassTransit middleware.
 - **Per-consumer concurrency control** — `[ConsumerConcurrency(n)]` attribute to limit concurrent message processing per endpoint. When multiple consumers share a queue, the minimum value wins. `PrefetchCount` auto-aligns to the concurrency limit.
 - **Per-consumer timeout** — `[ConsumerTimeout(seconds)]` attribute to set a processing deadline per consumer. The `CancellationToken` passed to `ProcessAsync` will be cancelled after the configured duration.
+- **Quorum queues** — enable RabbitMQ quorum queues globally (`useQuorumQueues: true`) or per-consumer via `[QuorumQueue]` attribute, with optional replication factor and delivery limit. The attribute takes precedence over global configuration.
 - **Circuit breaker** — configurable circuit breaker (`useCircuitBreaker`) to stop processing when failure thresholds are exceeded, preventing cascading failures.
 - **Scheduled sending** — send messages at a future point in time using `ScheduleAsync` with a `TimeSpan` or `DateTime`.
 - **Custom message headers** — pass arbitrary headers via `IDictionary<string, string>` overloads of `SendAsync` / `ScheduleAsync`.

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusConfiguration.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusConfiguration.cs
@@ -22,4 +22,7 @@ public class MessageBusConfiguration
     public int CircuitBreakerTripThreshold { get; set; } = 10;
     public int CircuitBreakerActiveThreshold { get; set; } = 5;
     public int CircuitBreakerResetIntervalSeconds { get; set; } = 60;
+    public bool UseQuorumQueues { get; set; }
+    public int? QuorumQueueReplicationFactor { get; set; }
+    public int? DeliveryLimit { get; set; }
 }

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusPlugin.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusPlugin.cs
@@ -73,6 +73,18 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
         return limits.Length > 0 ? limits.Min() : null;
     }
 
+    private static int? GetQuorumQueueReplicationFactorFromConsumers(Type[] consumerTypes)
+    {
+        var attributes = consumerTypes
+            .Select(t => t.GetAttribute<QuorumQueueAttribute>())
+            .Where(a => a is not null)
+            .ToArray();
+        if (attributes.Length == 0)
+            return null;
+        var factors = attributes.Select(a => a!.ReplicationFactor).Where(f => f > 0).ToArray();
+        return factors.Length > 0 ? factors.Min() : 0;
+    }
+
     private void ConfigureMassTransit(IServiceCollection serviceCollection, Type[] messageTypes, IList<QueueMessageTypes> queueGroups)
     {
         var consumerType = typeof(MessageConsumer<>);
@@ -117,6 +129,20 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
                                 configurator.PrefetchCount = configuration.PrefetchCount.Value;
                             }
 
+                            var quorumReplicationFactor = GetQuorumQueueReplicationFactorFromConsumers(queueGroup.ConsumerTypes);
+                            if (quorumReplicationFactor.HasValue)
+                            {
+                                configurator.SetQuorumQueue(quorumReplicationFactor.Value > 0 ? quorumReplicationFactor.Value : null);
+                                if (configuration.DeliveryLimit.HasValue)
+                                    configurator.SetQueueArgument("x-delivery-limit", configuration.DeliveryLimit.Value);
+                            }
+                            else if (configuration.UseQuorumQueues)
+                            {
+                                configurator.SetQuorumQueue(configuration.QuorumQueueReplicationFactor);
+                                if (configuration.DeliveryLimit.HasValue)
+                                    configurator.SetQueueArgument("x-delivery-limit", configuration.DeliveryLimit.Value);
+                            }
+
                             configurators.ForEach(x => x.ConfigureReceiveEndpoint(context, queueGroup.Queue, queueGroup.ConsumerTypes, configurator));
 
                             if (configuration.UseCircuitBreaker)
@@ -129,14 +155,16 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
                                 });
                             }
 
-                            configurator.UseMessageScope(context);
-                            configurator.UseInMemoryOutbox(context);
+                            configurator.UseDelayedRedelivery(r => r.Interval(configuration.MaxRedeliveryCount, TimeSpan.FromSeconds(configuration.RedeliveryDelaySeconds)));
 
                             if (configuration.UseRetry)
                             {
                                 configurator.UseMessageRetry(r => r.Interval(configuration.MaxRetryCount, TimeSpan.FromSeconds(configuration.RetryDelaySeconds)));
                             }
-                            configurator.UseDelayedRedelivery(r => r.Interval(configuration.MaxRedeliveryCount, TimeSpan.FromSeconds(configuration.RedeliveryDelaySeconds)));
+
+                            configurator.UseMessageScope(context);
+                            configurator.UseInMemoryOutbox(context);
+
                             foreach (var messageType in queueGroup.MessageTypes)
                                 configurator.ConfigureConsumer(context, consumerType.MakeGenericType(messageType));
                         });

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusPlugin.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageBusPlugin.cs
@@ -28,7 +28,7 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
             from @interface in messageConsumer.GetInterfaces()
                 .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IMessageConsumer<>))
             let messageType = @interface.GetGenericArguments().First()
-            let queueName = QueueResolver.Resolve(messageType)
+            let queueName = QueueResolver.BuildListenAddress(messageType)
             select (queueName, messageType, consumerType: messageConsumer)).ToList();
         return entries.GroupBy(x => x.queueName)
             .Select(x =>
@@ -52,10 +52,13 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
         var messageTypes = queueGroups.SelectMany(x => x.MessageTypes).Distinct().ToArray();
         serviceCollection.AddSingleton<IMessageValidator>(new MessageValidator(messageTypes));
         serviceCollection.AddSingleton<IMessageDeduplicateKeyProvider>(new MessageDeduplicateKeyProvider(configuration));
+        var queueResolver = new QueueResolver(configuration, queueGroups.Select(qg => (qg.Queue, qg.ConsumerTypes)).ToList());
+        serviceCollection.AddSingleton<IQueueResolver>(queueResolver);
         serviceCollection.AddSingleton<IMessageBus>(sp => new MessageSender(sp.GetRequiredService<IDateTimeProvider>(),
             sp.GetRequiredService<ISendEndpointProvider>(),
             sp.GetRequiredService<IMessageValidator>(),
-            sp.GetService<IMessageScheduler>(), sp.GetRequiredService<IMessageDeduplicateKeyProvider>()));
+            sp.GetService<IMessageScheduler>(), sp.GetRequiredService<IMessageDeduplicateKeyProvider>(),
+            sp.GetRequiredService<IQueueResolver>()));
         ConfigureMassTransit(serviceCollection, messageTypes, queueGroups);
         serviceCollection.AddOpenTelemetry().WithTracing(builder =>
         {
@@ -71,18 +74,6 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
             .Select(a => a!.ConcurrencyLimit)
             .ToArray();
         return limits.Length > 0 ? limits.Min() : null;
-    }
-
-    private static int? GetQuorumQueueReplicationFactorFromConsumers(Type[] consumerTypes)
-    {
-        var attributes = consumerTypes
-            .Select(t => t.GetAttribute<QuorumQueueAttribute>())
-            .Where(a => a is not null)
-            .ToArray();
-        if (attributes.Length == 0)
-            return null;
-        var factors = attributes.Select(a => a!.ReplicationFactor).Where(f => f > 0).ToArray();
-        return factors.Length > 0 ? factors.Min() : 0;
     }
 
     private void ConfigureMassTransit(IServiceCollection serviceCollection, Type[] messageTypes, IList<QueueMessageTypes> queueGroups)
@@ -129,7 +120,7 @@ public class MessageBusPlugin(IImplementationResolver implementationResolver, Me
                                 configurator.PrefetchCount = configuration.PrefetchCount.Value;
                             }
 
-                            var quorumReplicationFactor = GetQuorumQueueReplicationFactorFromConsumers(queueGroup.ConsumerTypes);
+                            var quorumReplicationFactor = QueueResolver.GetQuorumQueueReplicationFactorFromConsumers(queueGroup.ConsumerTypes);
                             if (quorumReplicationFactor.HasValue)
                             {
                                 configurator.SetQuorumQueue(quorumReplicationFactor.Value > 0 ? quorumReplicationFactor.Value : null);

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageSender.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/MessageSender.cs
@@ -10,7 +10,9 @@ namespace Dosaic.Plugins.Messaging.MassTransit
         ISendEndpointProvider provider,
         IMessageValidator messageValidator,
         IMessageScheduler scheduler,
-        IMessageDeduplicateKeyProvider deduplicateKeyProvider) : IMessageBus
+        IMessageDeduplicateKeyProvider deduplicateKeyProvider,
+        IQueueResolver queueResolver) : IMessageBus
+
     {
         private readonly ConcurrentDictionary<Uri, ISendEndpoint> _sendEndpoints = new();
         private const string DedupeHeader = "x-deduplication-header";
@@ -59,7 +61,7 @@ namespace Dosaic.Plugins.Messaging.MassTransit
             if (scheduler is null)
                 throw new InvalidOperationException("Scheduler is not available and must be configured!");
             if (!messageValidator.HasConsumers(messageType)) return;
-            var queue = QueueResolver.Resolve(messageType);
+            var queue = queueResolver.ResolveSendAddress(messageType);
 
             await scheduler.ScheduleSend(
                 queue,
@@ -93,7 +95,7 @@ namespace Dosaic.Plugins.Messaging.MassTransit
 
         private async Task<ISendEndpoint> GetSendEndpoint(Type messageType)
         {
-            var address = QueueResolver.Resolve(messageType);
+            var address = queueResolver.ResolveSendAddress(messageType);
             if (_sendEndpoints.TryGetValue(address, out var endpoint))
                 return endpoint;
             var newEndpoint = await provider.GetSendEndpoint(address);

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/QueueResolver.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/QueueResolver.cs
@@ -1,12 +1,31 @@
 using System.Collections.Concurrent;
 using Dosaic.Hosting.Abstractions.Extensions;
-using Dosaic.Plugins.Messaging.Abstractions;
 
 namespace Dosaic.Plugins.Messaging.MassTransit;
 
-public static class QueueResolver
+public interface IQueueResolver
 {
-    private static readonly IDictionary<Type, Uri> _queueNames = new ConcurrentDictionary<Type, Uri>();
+    Uri ResolveListenAddress(Type messageType);
+    Uri ResolveSendAddress(Type messageType);
+}
+
+public class QueueResolver : IQueueResolver
+{
+    private readonly ConcurrentDictionary<Type, Uri> _listenAddresses = new();
+    private readonly ConcurrentDictionary<Type, Uri> _sendAddresses = new();
+    private readonly IReadOnlySet<Uri> _quorumQueues;
+
+    public QueueResolver(MessageBusConfiguration configuration, IList<(Uri Queue, Type[] ConsumerTypes)> queueGroups)
+    {
+        var quorumQueues = new HashSet<Uri>();
+        foreach (var (queue, consumerTypes) in queueGroups)
+        {
+            if (configuration.UseQuorumQueues ||
+                GetQuorumQueueReplicationFactorFromConsumers(consumerTypes).HasValue)
+                quorumQueues.Add(queue);
+        }
+        _quorumQueues = quorumQueues;
+    }
 
     public static string GetQueueNameFromType(Type t)
     {
@@ -17,15 +36,38 @@ public static class QueueResolver
         return t.Name.Split('`')[0] + "-" + string.Join("-", t.GetGenericArguments().Select(GetQueueNameFromType));
     }
 
-    public static Uri Resolve(Type t)
+    public static Uri BuildListenAddress(Type t)
     {
-        if (_queueNames.TryGetValue(t, out var value))
-            return value;
-        var queueName = new Uri($"queue:{GetQueueNameFromType(t)}");
-        _queueNames.Add(t, queueName);
-        return queueName;
+        return new Uri($"queue:{GetQueueNameFromType(t)}");
     }
-    public static Uri Resolve<TMessage>() where TMessage : IMessage => Resolve(typeof(TMessage));
+
+    public Uri ResolveListenAddress(Type messageType)
+    {
+        return _listenAddresses.GetOrAdd(messageType, BuildListenAddress);
+    }
+
+    public Uri ResolveSendAddress(Type messageType)
+    {
+        return _sendAddresses.GetOrAdd(messageType, t =>
+        {
+            var listenAddress = ResolveListenAddress(t);
+            return _quorumQueues.Contains(listenAddress)
+                ? new Uri($"exchange:{listenAddress.PathAndQuery}")
+                : listenAddress;
+        });
+    }
+
+    internal static int? GetQuorumQueueReplicationFactorFromConsumers(Type[] consumerTypes)
+    {
+        var attributes = consumerTypes
+            .Select(t => t.GetAttribute<QuorumQueueAttribute>())
+            .Where(a => a is not null)
+            .ToArray();
+        if (attributes.Length == 0)
+            return null;
+        var factors = attributes.Select(a => a!.ReplicationFactor).Where(f => f > 0).ToArray();
+        return factors.Length > 0 ? factors.Min() : 0;
+    }
 }
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/QuorumQueueAttribute.cs
+++ b/Plugins/Messaging/MassTransit/src/Dosaic.Plugins.Messaging.MassTransit/QuorumQueueAttribute.cs
@@ -1,0 +1,13 @@
+namespace Dosaic.Plugins.Messaging.MassTransit;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class QuorumQueueAttribute : Attribute
+{
+    public QuorumQueueAttribute(int replicationFactor = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(replicationFactor);
+        ReplicationFactor = replicationFactor;
+    }
+
+    public int ReplicationFactor { get; }
+}

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/ConsumerConcurrencyAttributeTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/ConsumerConcurrencyAttributeTests.cs
@@ -1,0 +1,28 @@
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Dosaic.Plugins.Messaging.MassTransit.Tests;
+
+public class ConsumerConcurrencyAttributeTests
+{
+    [Test]
+    public void ShouldCreateWithSpecifiedConcurrencyLimit()
+    {
+        var attribute = new ConsumerConcurrencyAttribute(10);
+        attribute.ConcurrencyLimit.Should().Be(10);
+    }
+
+    [Test]
+    public void ShouldRejectZeroConcurrencyLimit()
+    {
+        var act = () => new ConsumerConcurrencyAttribute(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void ShouldRejectNegativeConcurrencyLimit()
+    {
+        var act = () => new ConsumerConcurrencyAttribute(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageBusConfiguratorTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageBusConfiguratorTests.cs
@@ -1,0 +1,64 @@
+using AwesomeAssertions;
+using MassTransit;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Dosaic.Plugins.Messaging.MassTransit.Tests;
+
+public class MessageBusConfiguratorTests
+{
+    private class TestConfigurator : IMessageBusConfigurator;
+
+    private class DelegatingConfigurator : IMessageBusConfigurator
+    {
+        public bool ThreeParamCalled { get; private set; }
+        public Uri ReceivedQueue { get; private set; }
+
+        void IMessageBusConfigurator.ConfigureReceiveEndpoint(IBusRegistrationContext context, Uri queue,
+            IRabbitMqReceiveEndpointConfigurator configurator)
+        {
+            ThreeParamCalled = true;
+            ReceivedQueue = queue;
+        }
+    }
+
+    [Test]
+    public void ConfigureMassTransitShouldBeNoOp()
+    {
+        IMessageBusConfigurator configurator = new TestConfigurator();
+        var opts = Substitute.For<IBusRegistrationConfigurator>();
+        configurator.ConfigureMassTransit(opts);
+    }
+
+    [Test]
+    public void ConfigureRabbitMqShouldBeNoOp()
+    {
+        IMessageBusConfigurator configurator = new TestConfigurator();
+        var context = Substitute.For<IBusRegistrationContext>();
+        var config = Substitute.For<IRabbitMqBusFactoryConfigurator>();
+        configurator.ConfigureRabbitMq(context, config);
+    }
+
+    [Test]
+    public void ConfigureReceiveEndpointShouldBeNoOp()
+    {
+        IMessageBusConfigurator configurator = new TestConfigurator();
+        var context = Substitute.For<IBusRegistrationContext>();
+        var queue = new Uri("queue:test");
+        var endpointConfigurator = Substitute.For<IRabbitMqReceiveEndpointConfigurator>();
+        configurator.ConfigureReceiveEndpoint(context, queue, endpointConfigurator);
+    }
+
+    [Test]
+    public void FourParamConfigureReceiveEndpointShouldDelegateToThreeParam()
+    {
+        var configurator = new DelegatingConfigurator();
+        var context = Substitute.For<IBusRegistrationContext>();
+        var queue = new Uri("queue:test");
+        var endpointConfigurator = Substitute.For<IRabbitMqReceiveEndpointConfigurator>();
+        ((IMessageBusConfigurator)configurator).ConfigureReceiveEndpoint(context, queue, [typeof(string)],
+            endpointConfigurator);
+        configurator.ThreeParamCalled.Should().BeTrue();
+        configurator.ReceivedQueue.Should().Be(queue);
+    }
+}

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageBusPluginTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageBusPluginTests.cs
@@ -117,4 +117,209 @@ public class MessageBusPluginTests
             return Task.CompletedTask;
         }
     }
+
+    internal record QuorumTestMessage : IMessage;
+
+    [QuorumQueue(5)]
+    internal class QuorumTestConsumer : IMessageConsumer<QuorumTestMessage>
+    {
+        public Task ProcessAsync(QuorumTestMessage message, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    internal record QuorumDefaultTestMessage : IMessage;
+
+    [QuorumQueue]
+    internal class QuorumDefaultTestConsumer : IMessageConsumer<QuorumDefaultTestMessage>
+    {
+        public Task ProcessAsync(QuorumDefaultTestMessage message, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private static Dictionary<string, IDictionary<string, object>> GetEndpointQueueArguments(IServiceProvider sp)
+    {
+        var bus = sp.GetRequiredService<IBus>();
+        var host = bus.GetInaccessibleValue<RabbitMqHost>("_host");
+        var endpoints = host.GetInaccessibleValue<ReceiveEndpointCollection>("ReceiveEndpoints")
+            .GetInaccessibleValue<SingleThreadedDictionary<string, ReceiveEndpoint>>("_endpoints");
+        var result = new Dictionary<string, IDictionary<string, object>>();
+        foreach (var kvp in endpoints)
+        {
+            var queueArgs = kvp.Value
+                .GetInaccessibleValue<object>("_context")
+                .GetInaccessibleValue<object>("_configuration")
+                .GetInaccessibleValue<object>("_settings")
+                .GetInaccessibleValue<IDictionary<string, object>>("QueueArguments");
+            result[kvp.Key] = queueArgs;
+        }
+        return result;
+    }
+
+    [Test]
+    public void ShouldConfigureQuorumQueuesFromGlobalConfig()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest",
+            UseQuorumQueues = true,
+            QuorumQueueReplicationFactor = 3
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        allArgs.Should().ContainKey(nameof(TestMessage));
+        allArgs[nameof(TestMessage)].Should().Contain("x-queue-type", "quorum");
+    }
+
+    [Test]
+    public void ShouldConfigureQuorumQueuesFromAttribute()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest"
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        allArgs.Should().ContainKey(nameof(QuorumTestMessage));
+        var args = allArgs[nameof(QuorumTestMessage)];
+        args.Should().Contain("x-queue-type", "quorum");
+        args.Should().Contain("x-quorum-initial-group-size", 5);
+    }
+
+    [Test]
+    public void ShouldPreferAttributeOverGlobalConfig()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest",
+            UseQuorumQueues = true,
+            QuorumQueueReplicationFactor = 3
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        var args = allArgs[nameof(QuorumTestMessage)];
+        args.Should().Contain("x-quorum-initial-group-size", 5);
+    }
+
+    [Test]
+    public void ShouldNotUseQuorumQueuesWhenDisabled()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest"
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        allArgs[nameof(TestMessage)].Should().NotContainKey("x-queue-type");
+    }
+
+    [Test]
+    public void ShouldSetDeliveryLimitOnQuorumQueues()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest",
+            UseQuorumQueues = true,
+            DeliveryLimit = 5
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        var args = allArgs[nameof(TestMessage)];
+        args.Should().Contain("x-queue-type", "quorum");
+        args.Should().Contain("x-delivery-limit", 5);
+    }
+
+    [Test]
+    public void ShouldNotSetDeliveryLimitOnClassicQueues()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest",
+            DeliveryLimit = 5
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        allArgs[nameof(TestMessage)].Should().NotContainKey("x-queue-type");
+        allArgs[nameof(TestMessage)].Should().NotContainKey("x-delivery-limit");
+    }
+
+    [Test]
+    public void ShouldSetDeliveryLimitOnAttributeQuorumQueues()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest",
+            DeliveryLimit = 10
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        var args = allArgs[nameof(QuorumTestMessage)];
+        args.Should().Contain("x-queue-type", "quorum");
+        args.Should().Contain("x-delivery-limit", 10);
+    }
+
+    [Test]
+    public void ShouldConfigureQuorumQueueFromAttributeWithDefaultReplicationFactor()
+    {
+        var config = new MessageBusConfiguration
+        {
+            Host = "localhost",
+            Username = "guest",
+            Password = "guest"
+        };
+        var plugin = new MessageBusPlugin(_implementationResolver, config, [_configurator]);
+        var sc = TestingDefaults.ServiceCollection();
+        plugin.ConfigureServices(sc);
+        var sp = sc.BuildServiceProvider();
+
+        var allArgs = GetEndpointQueueArguments(sp);
+        var args = allArgs[nameof(QuorumDefaultTestMessage)];
+        args.Should().Contain("x-queue-type", "quorum");
+        args.Should().NotContainKey("x-quorum-initial-group-size");
+    }
 }

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageSenderTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/MessageSenderTests.cs
@@ -18,6 +18,7 @@ public class MessageSenderTests
     private IDateTimeProvider _dateTimeProvider;
     private ISendEndpoint _sendEndpoint;
     private IMessageDeduplicateKeyProvider _deduplicateKeyProvider;
+    private IQueueResolver _queueResolver;
     private static readonly DateTime _now = DateTime.UtcNow;
 
     [SetUp]
@@ -36,7 +37,8 @@ public class MessageSenderTests
                 Deduplication = true,
                 Host = "localhost"
             });
-        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, _scheduler, _deduplicateKeyProvider);
+        _queueResolver = new QueueResolver(new MessageBusConfiguration { Host = "localhost" }, []);
+        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, _scheduler, _deduplicateKeyProvider, _queueResolver);
     }
 
     [Test]
@@ -82,7 +84,7 @@ public class MessageSenderTests
     [Test]
     public async Task ThrowsExceptionWhenSchedulerIsNotPresent()
     {
-        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, null, _deduplicateKeyProvider);
+        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, null, _deduplicateKeyProvider, _queueResolver);
         await _messageBus.Invoking(x => x.ScheduleAsync(new TestMessage(123), TimeSpan.FromSeconds(1)))
             .Should().ThrowAsync<InvalidOperationException>();
     }
@@ -283,6 +285,42 @@ public class MessageSenderTests
 
         durableWasSet = localDurableWasSet;
         return headers;
+    }
+
+    [Test]
+    public async Task SendAsyncUsesExchangeUriForQuorumQueues()
+    {
+        var listenAddress = QueueResolver.BuildListenAddress(typeof(TestMessage));
+        var quorumResolver = new QueueResolver(
+            new MessageBusConfiguration { Host = "localhost", UseQuorumQueues = true },
+            [(listenAddress, [typeof(TestMessage)])]);
+        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, _scheduler, _deduplicateKeyProvider, quorumResolver);
+        _messageValidator.HasConsumers(typeof(TestMessage)).Returns(true);
+        _deduplicateKeyProvider = Substitute.For<IMessageDeduplicateKeyProvider>();
+        await _messageBus.SendAsync(new TestMessage(1));
+        await _sendEndpointProvider.Received(1).GetSendEndpoint(Arg.Is<Uri>(u => u.Scheme == "exchange"));
+    }
+
+    [Test]
+    public async Task SendAsyncUsesQueueUriForClassicQueues()
+    {
+        _messageValidator.HasConsumers(typeof(TestMessage)).Returns(true);
+        _deduplicateKeyProvider = Substitute.For<IMessageDeduplicateKeyProvider>();
+        await _messageBus.SendAsync(new TestMessage(1));
+        await _sendEndpointProvider.Received(1).GetSendEndpoint(Arg.Is<Uri>(u => u.Scheme == "queue"));
+    }
+
+    [Test]
+    public async Task ScheduleAsyncUsesExchangeUriForQuorumQueues()
+    {
+        var listenAddress = QueueResolver.BuildListenAddress(typeof(TestMessage));
+        var quorumResolver = new QueueResolver(
+            new MessageBusConfiguration { Host = "localhost", UseQuorumQueues = true },
+            [(listenAddress, [typeof(TestMessage)])]);
+        _messageBus = new MessageSender(_dateTimeProvider, _sendEndpointProvider, _messageValidator, _scheduler, _deduplicateKeyProvider, quorumResolver);
+        _messageValidator.HasConsumers(typeof(TestMessage)).Returns(true);
+        await _messageBus.ScheduleAsync(new TestMessage(1), TimeSpan.FromSeconds(1));
+        await _scheduler.Received(1).ScheduleSend(Arg.Is<Uri>(u => u.Scheme == "exchange"), Arg.Any<DateTime>(), Arg.Any<object>(), typeof(TestMessage), Arg.Any<IPipe<SendContext>>(), Arg.Any<CancellationToken>());
     }
 
     private record TestMessage(int Id) : IMessage;

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/QueueResolverTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/QueueResolverTests.cs
@@ -6,25 +6,49 @@ namespace Dosaic.Plugins.Messaging.MassTransit.Tests;
 
 public class QueueResolverTests
 {
-    [Test]
-    public void ShouldResolveQueueNameFromAttribute()
+    private QueueResolver _resolver;
+
+    [SetUp]
+    public void Setup()
     {
-        QueueResolver.Resolve<AttrMessage>().Should().Be("queue:Attr_queue");
-        QueueResolver.Resolve<AttrMessage>().Should().Be("queue:Attr_queue");
+        _resolver = new QueueResolver(new MessageBusConfiguration { Host = "localhost" }, []);
     }
 
     [Test]
-    public void ShouldResolveQueueNameFromTypeName()
+    public void ShouldResolveListenAddressFromAttribute()
     {
-        QueueResolver.Resolve<TypeMessage>().Should().Be("queue:TypeMessage");
-        QueueResolver.Resolve<TypeMessage>().Should().Be("queue:TypeMessage");
+        _resolver.ResolveListenAddress(typeof(AttrMessage)).Should().Be("queue:Attr_queue");
+        _resolver.ResolveListenAddress(typeof(AttrMessage)).Should().Be("queue:Attr_queue");
     }
 
     [Test]
-    public void ShouldResolveQueueNameFromGenerics()
+    public void ShouldResolveListenAddressFromTypeName()
     {
-        QueueResolver.Resolve<GenericMessage<int, decimal>>().Should().Be("queue:GenericMessage-Int32-Decimal");
-        QueueResolver.Resolve<GenericMessage<int, decimal>>().Should().Be("queue:GenericMessage-Int32-Decimal");
+        _resolver.ResolveListenAddress(typeof(TypeMessage)).Should().Be("queue:TypeMessage");
+        _resolver.ResolveListenAddress(typeof(TypeMessage)).Should().Be("queue:TypeMessage");
+    }
+
+    [Test]
+    public void ShouldResolveListenAddressFromGenerics()
+    {
+        _resolver.ResolveListenAddress(typeof(GenericMessage<int, decimal>)).Should().Be("queue:GenericMessage-Int32-Decimal");
+        _resolver.ResolveListenAddress(typeof(GenericMessage<int, decimal>)).Should().Be("queue:GenericMessage-Int32-Decimal");
+    }
+
+    [Test]
+    public void ShouldResolveSendAddressAsExchangeForQuorumQueues()
+    {
+        var listenAddress = QueueResolver.BuildListenAddress(typeof(TypeMessage));
+        var resolver = new QueueResolver(
+            new MessageBusConfiguration { Host = "localhost", UseQuorumQueues = true },
+            [(listenAddress, [typeof(TypeMessage)])]);
+        resolver.ResolveSendAddress(typeof(TypeMessage)).Should().Be("exchange:TypeMessage");
+    }
+
+    [Test]
+    public void ShouldResolveSendAddressAsQueueForClassicQueues()
+    {
+        _resolver.ResolveSendAddress(typeof(TypeMessage)).Should().Be("queue:TypeMessage");
     }
 
     [QueueName("Attr_queue")]

--- a/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/QuorumQueueAttributeTests.cs
+++ b/Plugins/Messaging/MassTransit/test/Dosaic.Plugins.Messaging.MassTransit.Tests/QuorumQueueAttributeTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+using NUnit.Framework;
+
+namespace Dosaic.Plugins.Messaging.MassTransit.Tests;
+
+public class QuorumQueueAttributeTests
+{
+    [Test]
+    public void ShouldCreateWithDefaultReplicationFactor()
+    {
+        var attribute = new QuorumQueueAttribute();
+        attribute.ReplicationFactor.Should().Be(0);
+    }
+
+    [Test]
+    public void ShouldCreateWithSpecifiedReplicationFactor()
+    {
+        var attribute = new QuorumQueueAttribute(5);
+        attribute.ReplicationFactor.Should().Be(5);
+    }
+
+    [Test]
+    public void ShouldRejectNegativeReplicationFactor()
+    {
+        var act = () => new QuorumQueueAttribute(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void ShouldAllowZeroReplicationFactor()
+    {
+        var attribute = new QuorumQueueAttribute(0);
+        attribute.ReplicationFactor.Should().Be(0);
+    }
+}


### PR DESCRIPTION
This pull request introduces the fix for middleware ordering and includes support for RabbitMQ quorum queues in the MassTransit messaging plugin, allowing them to be enabled globally or per-consumer, with configurable replication factor and delivery limits. It adds a new `[QuorumQueue]` attribute, updates configuration options, and includes comprehensive tests to ensure correct behavior and precedence between global and per-consumer settings.

**Middleware order:**

The order of middleware was changed, that retry gets a fresh DI context.

**Quorum Queue Support:**

* Added `useQuorumQueues`, `quorumQueueReplicationFactor`, and `deliveryLimit` options to `MessageBusConfiguration` and documented them in the README, enabling global configuration of quorum queues and delivery limits. [[1]](diffhunk://#diff-a49e6ca7d368d4e95f0d63148fbcb67ecc2518d547d418f3adea7f729e69bf66R40-R42) [[2]](diffhunk://#diff-a49e6ca7d368d4e95f0d63148fbcb67ecc2518d547d418f3adea7f729e69bf66R64-R66) [[3]](diffhunk://#diff-a8bb92cda6954b555c69cdee8f105a6715731034001d0f46477cb8d89827a2b5R25-R27)
* Introduced the `[QuorumQueue]` attribute, allowing per-consumer configuration of quorum queues with an optional replication factor, which takes precedence over global settings. [[1]](diffhunk://#diff-5425d47042efbb2e39b9f63d8f9633de9601ae7cdf657ebbff0c5691843bdb67R1-R13) [[2]](diffhunk://#diff-a49e6ca7d368d4e95f0d63148fbcb67ecc2518d547d418f3adea7f729e69bf66R152-R183)
* Updated the MassTransit plugin logic to apply quorum queue settings and delivery limits based on attribute and/or global configuration, ensuring correct precedence and application. [[1]](diffhunk://#diff-7fefd23756a7a5526325b8e28a8e7daf1a3c204e1503d5c3760aa2ebe5c4fa0eR76-R87) [[2]](diffhunk://#diff-7fefd23756a7a5526325b8e28a8e7daf1a3c204e1503d5c3760aa2ebe5c4fa0eR132-R145)

**Testing and Validation:**

* Added extensive unit tests for quorum queue configuration, including global vs. attribute precedence, delivery limit application, and default behaviors. [[1]](diffhunk://#diff-2bdfb27df87b4aa33cf7b31dadc63a1e0d7488aa9e6dcae7057f558117c93f3dR120-R324) [[2]](diffhunk://#diff-bac2f8859efad364b6d6b3419ea02d577d94adc2344f7aebb96c37edf89a2ceaR1-R35)
* Added tests for the existing `ConsumerConcurrencyAttribute` and `MessageBusConfigurator` to ensure robust attribute validation and configurator delegation. [[1]](diffhunk://#diff-99701a58b46cda1afdfaa304a05ad7f32555590e48c5e96d38950ffd28bceca3R1-R28) [[2]](diffhunk://#diff-05504318d1c8674b1f4500a671248ffcc28c8a5f0749686426813b00a75261cdR1-R64)

**Documentation:**

* Updated the README to explain quorum queue configuration (global and per-consumer), delivery limits, and their precedence, as well as to highlight this feature in the plugin capabilities summary. [[1]](diffhunk://#diff-a49e6ca7d368d4e95f0d63148fbcb67ecc2518d547d418f3adea7f729e69bf66R152-R183) [[2]](diffhunk://#diff-a49e6ca7d368d4e95f0d63148fbcb67ecc2518d547d418f3adea7f729e69bf66R306)