### PR TITLE
Make EnumSummarySchemaFilter public for OpenAPI accessibility

### DIFF
--- a/Api/OpenApi/src/Dosaic.Api.OpenApi/Filters/Schema/EnumSummarySchemaFilter.cs
+++ b/Api/OpenApi/src/Dosaic.Api.OpenApi/Filters/Schema/EnumSummarySchemaFilter.cs
@@ -10,7 +10,7 @@ namespace Dosaic.Api.OpenApi.Filters.Schema;
 /// <summary>
 ///     Adds XML summary comments from enum members to the OpenAPI schema description.
 /// </summary>
-internal class EnumSummarySchemaFilter : ISchemaFilter
+public class EnumSummarySchemaFilter : ISchemaFilter
 {
     private static readonly Lazy<XDocument> _xmlDoc = new(LoadXmlDoc);
 


### PR DESCRIPTION
This pull request makes a visibility change to the `EnumSummarySchemaFilter` class. The class has been made `public` instead of `internal` to allow it to be accessed outside its assembly.

* Changed the `EnumSummarySchemaFilter` class from `internal` to `public` in `EnumSummarySchemaFilter.cs` to make it accessible to other assemblies.