### PR TITLE
Refactor EnumSummarySchemaFilter for multiple XML docs and caching

### DIFF
--- a/Api/OpenApi/README.md
+++ b/Api/OpenApi/README.md
@@ -82,21 +82,24 @@ XML doc comments are picked up automatically. Enable XML output in your project 
 
 ### Enum member summaries (optional)
 
-`EnumSummarySchemaFilter` can append enum member XML summaries to the generated schema description.
+`EnumSummarySchemaFilter` appends enum member XML summaries to the generated schema description.
 
-- Works only for enum schemas.
+- Works for enum and `Nullable<TEnum>` schemas.
 - Skips members marked with `[OpenApiIgnore]`.
 - Skips members with empty or missing XML `<summary>` docs.
-- No-op if the XML documentation file is unavailable.
+- Resolves XML docs by the enum type's assembly (`{AssemblyName}.xml` next to the binary) and additionally searches any documentation files passed at registration.
+- No-op if no XML documentation can be resolved.
 
-Register it in your Swagger setup:
+`OpenApiPlugin` registers this filter by default and forwards the discovered XML files. If you configure Swagger manually, register it explicitly:
 
 ```csharp
 using Dosaic.Api.OpenApi.Filters.Schema;
 
 services.AddSwaggerGen(options =>
 {
-    options.SchemaFilter<EnumSummarySchemaFilter>();
+    // Optionally pass extra XML docs to search as fallback
+    var documentationFiles = Directory.GetFiles(AppContext.BaseDirectory, "*.xml");
+    options.SchemaFilter<EnumSummarySchemaFilter>(new object[] { documentationFiles });
 });
 ```
 

--- a/Api/OpenApi/src/Dosaic.Api.OpenApi/Filters/Schema/EnumSummarySchemaFilter.cs
+++ b/Api/OpenApi/src/Dosaic.Api.OpenApi/Filters/Schema/EnumSummarySchemaFilter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using System.Xml.Linq;
@@ -12,70 +13,92 @@ namespace Dosaic.Api.OpenApi.Filters.Schema;
 /// </summary>
 public class EnumSummarySchemaFilter : ISchemaFilter
 {
-    private static readonly Lazy<XDocument> _xmlDoc = new(LoadXmlDoc);
+    private static readonly ConcurrentDictionary<string, Lazy<XDocument>> _xmlDocCache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly string[] _documentationFiles;
+
+    public EnumSummarySchemaFilter() : this(null) { }
+
+    public EnumSummarySchemaFilter(string[] documentationFiles)
+    {
+        _documentationFiles = documentationFiles ?? Array.Empty<string>();
+    }
 
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        var type = context.Type;
-        if (!type.IsEnum)
-            return;
+        var enumType = Nullable.GetUnderlyingType(context.Type) ?? context.Type;
+        if (!enumType.IsEnum) return;
 
-        var doc = ResolveXmlDoc();
-        if (doc is null)
-            return;
+        var docs = ResolveXmlDocs(enumType);
+        if (docs.Count == 0) return;
 
         var entries = new List<string>();
-        foreach (var member in Enum.GetValues(type))
+        foreach (var member in Enum.GetValues(enumType))
         {
-            var memberInfo = ResolveMemberField(type, member);
-            if (memberInfo is null)
-                continue;
+            var field = ResolveMemberField(enumType, member);
+            if (field is null) continue;
+            if (field.GetCustomAttribute<OpenApiIgnoreAttribute>() is not null) continue;
 
-            if (memberInfo.GetCustomAttribute<OpenApiIgnoreAttribute>() is not null)
-                continue;
-
-            var summary = GetXmlSummary(doc, memberInfo);
-            if (string.IsNullOrWhiteSpace(summary))
-                continue;
+            var summary = GetXmlSummary(docs, field);
+            if (string.IsNullOrWhiteSpace(summary)) continue;
 
             var value = Convert.ToInt64(member, CultureInfo.InvariantCulture);
-            entries.Add($"- `{memberInfo.Name}` ({value}): {summary}");
+            entries.Add($"- `{field.Name}` ({value}): {summary}");
         }
 
-        if (entries.Count > 0)
-        {
-            var description = string.Join("\n", entries);
-            schema.Description = string.IsNullOrWhiteSpace(schema.Description)
-                ? description
-                : $"{schema.Description}\n\n{description}";
-        }
+        if (entries.Count == 0) return;
+
+        var description = string.Join("\n", entries);
+        schema.Description = string.IsNullOrWhiteSpace(schema.Description)
+            ? description
+            : $"{schema.Description}\n\n{description}";
     }
 
     protected virtual FieldInfo ResolveMemberField(Type type, object member)
     {
-        var memberName = Enum.GetName(type, member);
-        return memberName is null ? null : type.GetField(memberName);
+        var name = Enum.GetName(type, member);
+        return name is null ? null : type.GetField(name);
     }
 
-    protected virtual XDocument ResolveXmlDoc()
+    protected virtual IReadOnlyCollection<XDocument> ResolveXmlDocs(Type enumType)
     {
-        return _xmlDoc.Value;
+        var paths = new List<string>
+        {
+            Path.Combine(AppContext.BaseDirectory, $"{enumType.Assembly.GetName().Name}.xml")
+        };
+        paths.AddRange(_documentationFiles);
+
+        return paths
+            .Where(File.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(LoadXmlDoc)
+            .Where(doc => doc is not null)
+            .ToList();
     }
 
-    private static string GetXmlSummary(XDocument doc, FieldInfo field)
+    private static string GetXmlSummary(IReadOnlyCollection<XDocument> docs, FieldInfo field)
     {
-        var memberName = $"F:{field.DeclaringType!.FullName}.{field.Name}";
-        var memberElement = doc.Descendants("member")
-            .FirstOrDefault(m => m.Attribute("name")?.Value == memberName);
+        var declaringName = field.DeclaringType!.FullName!;
+        var memberName = $"F:{declaringName}.{field.Name}";
+        var nestedMemberName = $"F:{declaringName.Replace('+', '.')}.{field.Name}";
 
-        return memberElement?.Element("summary")?.Value.Trim();
+        foreach (var doc in docs)
+        {
+            var element = doc.Descendants("member").FirstOrDefault(m =>
+            {
+                var name = m.Attribute("name")?.Value;
+                return name == memberName || name == nestedMemberName;
+            });
+
+            var summary = element?.Element("summary")?.Value.Trim();
+            if (!string.IsNullOrWhiteSpace(summary)) return summary;
+        }
+
+        return null;
     }
 
-    private static XDocument LoadXmlDoc()
-    {
-        var assembly = typeof(EnumSummarySchemaFilter).Assembly;
-        var xmlFile = Path.Combine(AppContext.BaseDirectory, $"{assembly.GetName().Name}.xml");
-        return File.Exists(xmlFile) ? XDocument.Load(xmlFile) : null;
-    }
+    private static XDocument LoadXmlDoc(string xmlFile) =>
+        _xmlDocCache.GetOrAdd(xmlFile, static path => new Lazy<XDocument>(() => XDocument.Load(path))).Value;
 }
 

--- a/Api/OpenApi/src/Dosaic.Api.OpenApi/OpenApiPlugin.cs
+++ b/Api/OpenApi/src/Dosaic.Api.OpenApi/OpenApiPlugin.cs
@@ -63,6 +63,7 @@ namespace Dosaic.Api.OpenApi
 
                 options.SchemaFilter<ReadOnlyPropertySchemaFilter>();
                 options.SchemaFilter<OpenApiIgnoreSchemaFilter>();
+                options.SchemaFilter<EnumSummarySchemaFilter>(new object[] { documentationFiles });
                 options.SchemaFilter<ValueObjectSchemaFilter>(new object[] { documentationFiles });
                 options.DocumentFilter<ValueObjectDocumentFilter>();
                 options.OperationFilter<FormFileFilter>();

--- a/Api/OpenApi/test/Dosaic.Api.OpenApi.Tests/Dosaic.Api.OpenApi.Tests.csproj
+++ b/Api/OpenApi/test/Dosaic.Api.OpenApi.Tests/Dosaic.Api.OpenApi.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-
-
-      <DocumentationFile>Dosaic.Api.OpenApi.xml</DocumentationFile>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Api/OpenApi/test/Dosaic.Api.OpenApi.Tests/Filters/Schema/EnumSummarySchemaFilterTests.cs
+++ b/Api/OpenApi/test/Dosaic.Api.OpenApi.Tests/Filters/Schema/EnumSummarySchemaFilterTests.cs
@@ -161,9 +161,9 @@ public class EnumSummarySchemaFilterTests
 
     private sealed class EnumSummarySchemaFilterWithMissingXmlDoc : EnumSummarySchemaFilter
     {
-        protected override XDocument ResolveXmlDoc()
+        protected override IReadOnlyCollection<XDocument> ResolveXmlDocs(Type enumType)
         {
-            return null;
+            return Array.Empty<XDocument>();
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the `EnumSummarySchemaFilter` to support improved XML documentation handling for enum schemas and their nullable counterparts. The filter now aggregates summaries from multiple XML documentation files, improving coverage for projects with multiple assemblies or custom documentation locations. The registration and test setup are also updated to reflect these changes.

**Enum summary filter improvements:**

- `EnumSummarySchemaFilter` now supports both enum and `Nullable<TEnum>` schemas, and can aggregate XML summaries from multiple documentation files, not just the default assembly XML. [[1]](diffhunk://#diff-ef50fe7e5143688739f1604cd2a8f858b22655885a7fcbbb6ab4308e725a92eaL85-R102) [[2]](diffhunk://#diff-f2b782bb365c371c8ca9caf37033ac0995b4814ebdc277519618cc8a223b370aL15-R102)
- The filter is now registered with all discovered XML documentation files by default in `OpenApiPlugin`, ensuring better summary coverage. [[1]](diffhunk://#diff-ef50fe7e5143688739f1604cd2a8f858b22655885a7fcbbb6ab4308e725a92eaL85-R102) [[2]](diffhunk://#diff-cd03ab1e8d96f73266ad17de3ec009d3dd64b5fa10a51ce78aa20a50543945b7R66)
- Improved logic for resolving enum member summaries, including handling of nested types and fallback to multiple XML files.

**Code and test updates:**

- Test project now generates XML documentation by default, ensuring summaries are available for test runs.
- Test class override updated to match new multi-file XML doc resolution logic.